### PR TITLE
Ignore `.idea` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ Temporary Items
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+.idea
 .idea/sonarlint
 
 # User-specific stuff


### PR DESCRIPTION
Can we ignore the `.idea` folder that is present in my project directory? The `.gitignore` section regarding JetBrains stuff is really comprehensive, still it does not cover this case. Moreover, I think that the IDE specific bits should not be part of the code-base/repo.