### PR TITLE
Add convenience methods to Stranded

### DIFF
--- a/src/main/java/org/monarchinitiative/variant/api/Stranded.java
+++ b/src/main/java/org/monarchinitiative/variant/api/Stranded.java
@@ -12,4 +12,12 @@ public interface Stranded<T> {
     default T toOppositeStrand() {
         return withStrand(strand().opposite());
     }
+
+    default T toPositiveStrand() {
+        return withStrand(Strand.POSITIVE);
+    }
+
+    default T toNegativeStrand() {
+        return withStrand(Strand.NEGATIVE);
+    }
 }


### PR DESCRIPTION
@julesjacobsen I propose adding default methods `toPositiveStrand()` and `toNegativeStrand()` to `Stranded`.

These methods would allow us to write a code that is easier to read. E.g.:

```java
Variant variant = ...
GenomicRegion region = variant.toPositiveStrand().toZeroBased();
```

instead of current

```java
Variant variant = ...
GenomicRegion region = variant.withStrand(Strand.POSITIVE).toZeroBased();
```

Please feel free to merge the PR if you agree.