### PR TITLE
Add convenience methods to Contig

### DIFF
--- a/src/main/java/org/monarchinitiative/variant/api/Contig.java
+++ b/src/main/java/org/monarchinitiative/variant/api/Contig.java
@@ -48,6 +48,13 @@ public interface Contig extends Comparable<Contig> {
     // UCSC-style-name column 9 (zero-based) of assembly-report
     String ucscName();
 
+    default boolean isKnownContig() {
+        return !isUnknownContig();
+    }
+
+    default boolean isUnknownContig() {
+        return this.equals(Contig.unknown());
+    }
     //# Sequence-Name	Sequence-Role	Assigned-Molecule	Assigned-Molecule-Location/Type	GenBank-Accn	Relationship	RefSeq-Accn	Assembly-Unit	Sequence-Length	UCSC-style-name
     // HUMAN (GRCh38.p13)
     // 1	assembled-molecule	1	Chromosome	CM000663.2	=	NC_000001.11	Primary Assembly	248956422	chr1

--- a/src/test/java/org/monarchinitiative/variant/api/ContigTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/ContigTest.java
@@ -1,0 +1,28 @@
+package org.monarchinitiative.variant.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+
+
+public class ContigTest {
+
+    @Test
+    public void properties() {
+        Contig contig = Contig.of(1, "1", SequenceRole.ASSEMBLED_MOLECULE, "1", AssignedMoleculeType.CHROMOSOME, 10, "CM000663.1", "NC_000001.10", "chr1");
+        assertThat(contig.id(), equalTo(1));
+        assertThat(contig.name(), equalTo("1"));
+        assertThat(contig.sequenceRole(), equalTo(SequenceRole.ASSEMBLED_MOLECULE));
+        assertThat(contig.assignedMolecule(), equalTo("1"));
+        assertThat(contig.assignedMoleculeType(), equalTo(AssignedMoleculeType.CHROMOSOME));
+        assertThat(contig.length(), equalTo(10));
+        assertThat(contig.genBankAccession(), equalTo("CM000663.1"));
+        assertThat(contig.refSeqAccession(), equalTo("NC_000001.10"));
+        assertThat(contig.ucscName(), equalTo("chr1"));
+        assertThat(contig.isKnownContig(), equalTo(true));
+        assertThat(contig.isUnknownContig(), equalTo(false));
+    }
+
+}


### PR DESCRIPTION
Allow to figure out whether a `Contig` instance represents a known contig or the `Contig.unknown()`.