### PR TITLE
Add region, allow empty regions, complete coordinate systems, GenomicPosition extends Position

### DIFF
--- a/src/main/java/org/monarchinitiative/variant/api/BaseGenomicPosition.java
+++ b/src/main/java/org/monarchinitiative/variant/api/BaseGenomicPosition.java
@@ -1,0 +1,144 @@
+package org.monarchinitiative.variant.api;
+
+import java.util.Objects;
+
+public abstract class BaseGenomicPosition<T extends GenomicPosition> implements GenomicPosition {
+
+    private final Contig contig;
+    private final Strand strand;
+    private final Position position;
+
+    protected BaseGenomicPosition(Contig contig, Strand strand, Position position) {
+        this.contig = Objects.requireNonNull(contig, "contig must not be null");
+        this.strand = Objects.requireNonNull(strand, "strand must not be null");
+        this.position = Objects.requireNonNull(position, "position must not be null");
+
+        if ((position.minPos() < 0)) {
+            throw new IllegalArgumentException("Cannot create genomic position " + position + " that extends beyond first contig base");
+        }
+        if (position.maxPos() > contig.length()) {
+            throw new IllegalArgumentException("Cannot create genomic position " + position + " that extends beyond contig end " + contig.length());
+        }
+    }
+
+    protected BaseGenomicPosition(Builder<?> builder) {
+        this(builder.contig, builder.strand, builder.position);
+    }
+
+    @Override
+    public Contig contig() {
+        return contig;
+    }
+
+    @Override
+    public Strand strand() {
+        return strand;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T withPos(int pos) {
+        return pos() == pos ? (T) this : newPositionInstance(contig, strand, position.withPos(pos));
+    }
+
+    @Override
+    public int pos() {
+        return position.pos();
+    }
+
+    @Override
+    public ConfidenceInterval confidenceInterval() {
+        return position.confidenceInterval();
+    }
+
+    @Override
+    public int minPos() {
+        return position.minPos();
+    }
+
+    @Override
+    public int maxPos() {
+        return position.maxPos();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T asPrecise() {
+        return isPrecise() ? (T) this : newPositionInstance(contig, strand, position.asPrecise());
+    }
+
+    @Override
+    public T invert(Contig contig, CoordinateSystem coordinateSystem) {
+        return newPositionInstance(contig, strand, position.invert(contig, coordinateSystem));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public T withStrand(Strand other) {
+        if (this.strand == other)
+            return (T) this;
+
+        Position inverted = position.invert(contig, CoordinateSystem.ONE_BASED);
+        return newPositionInstance(contig, other, inverted);
+    }
+
+    protected abstract T newPositionInstance(Contig contig, Strand strand, Position position);
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BaseGenomicPosition<?> that = (BaseGenomicPosition<?>) o;
+        return Objects.equals(contig, that.contig) && strand == that.strand && Objects.equals(position, that.position);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(contig, strand, position);
+    }
+
+    @Override
+    public String toString() {
+        return "BaseGenomicPosition{" +
+                "contig=" + contig +
+                ", strand=" + strand +
+                ", position=" + position +
+                '}';
+    }
+
+    protected abstract static class Builder<T extends Builder<T>> {
+
+        protected Contig contig;
+        protected Strand strand = Strand.POSITIVE;
+        protected Position position = Position.of(1);
+
+        public T with(Contig contig, Strand strand, Position position) {
+            this.contig = contig;
+            this.strand = strand;
+            this.position = position;
+            return self();
+        }
+
+        public T withStrand(Strand strand) {
+            if (this.strand == strand)
+                return self();
+
+            this.strand = strand;
+            this.position = position.invert(contig, CoordinateSystem.ONE_BASED);
+            return self();
+        }
+
+        public T onPositiveStrand() {
+            return withStrand(Strand.POSITIVE);
+        }
+
+        public T onNegativeStrand() {
+            return withStrand(Strand.NEGATIVE);
+        }
+
+        protected abstract GenomicPosition build();
+
+        protected abstract T self();
+    }
+
+}

--- a/src/main/java/org/monarchinitiative/variant/api/BaseVariant.java
+++ b/src/main/java/org/monarchinitiative/variant/api/BaseVariant.java
@@ -30,7 +30,7 @@ public abstract class BaseVariant<T extends Variant> extends BaseGenomicRegion<T
     }
 
     private int checkChangeLength(int changeLength, Position endPosition, VariantType variantType) {
-        int startZeroBased = normalisedStartPosition(CoordinateSystem.ZERO_BASED).pos();
+        int startZeroBased = normalisedStart(Endpoint.OPEN);
         if (variantType.baseType() == VariantType.DEL && startZeroBased - (endPosition.pos() - 1) != changeLength) {
             throw new IllegalArgumentException("Illegal DEL changeLength:" + changeLength + ". Does not match expected " + (startZeroBased - (endPosition.pos() - 1) + " given coordinates " + coordinates()));
         } else if (variantType.baseType() == VariantType.INS && (changeLength <= 0)) {
@@ -80,7 +80,9 @@ public abstract class BaseVariant<T extends Variant> extends BaseGenomicRegion<T
         if (this.coordinateSystem() == coordinateSystem) {
             return (T) this;
         }
-        return newVariantInstance(contig(), id, strand(), coordinateSystem, normalisedStartPosition(coordinateSystem), endPosition(), ref, alt, changeLength);
+        return newVariantInstance(contig(), id, strand(), coordinateSystem,
+                normalisedStartPosition(coordinateSystem.startEndpoint()), normalisedEndPosition(coordinateSystem.endEndpoint()),
+                ref, alt, changeLength);
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/CoordinateSystem.java
+++ b/src/main/java/org/monarchinitiative/variant/api/CoordinateSystem.java
@@ -30,7 +30,11 @@ public enum CoordinateSystem {
      * For example, the region between the 3rd and the 7th bases, where the end base is included, is (2,7]. The BAM,
      * BCFv2, BED, and PSL formats use the 0-based coordinate system.
      */
-    ZERO_BASED(Endpoint.OPEN, Endpoint.CLOSED);
+    ZERO_BASED(Endpoint.OPEN, Endpoint.CLOSED),
+
+    RIGHT_OPEN(Endpoint.CLOSED, Endpoint.OPEN),
+
+    FULLY_OPEN(Endpoint.OPEN, Endpoint.OPEN);
 
     private final Endpoint start;
     private final Endpoint end;
@@ -38,6 +42,26 @@ public enum CoordinateSystem {
     CoordinateSystem(Endpoint start, Endpoint end) {
         this.start = start;
         this.end = end;
+    }
+
+    /**
+     * Returns the required delta to shift a start position from the <code>current</code> endpoint to the
+     * <code>required</code> one.
+     *
+     * @return an integer in the range [-1, 0, 1]
+     */
+    public static int startDelta(Endpoint current, Endpoint required) {
+        return current == required ? 0 : current == Endpoint.OPEN ? 1 : -1;
+    }
+
+    /**
+     * Returns the required delta to shift an end position from the <code>current</code> endpoint to the
+     * <code>required</code> one.
+     *
+     * @return an integer in the range [-1, 0, 1]
+     */
+    public static int endDelta(Endpoint current, Endpoint required) {
+        return current == required ? 0 : current == Endpoint.OPEN ? -1 : 1;
     }
 
     public boolean isOneBased() {
@@ -48,26 +72,33 @@ public enum CoordinateSystem {
         return this == ZERO_BASED;
     }
 
-    /**
-     * Returns the required delta to shift a start position from the <code>current</code> system to the <code>required</code> one.
-     *
-     * @return an integer in the range [-1, 0, 1]
-     */
-    public static int startDelta(CoordinateSystem current, CoordinateSystem required) {
-        if (current == required) {
-            return 0;
-        }
-        return current == ZERO_BASED ? 1 : -1;
+    public Endpoint startEndpoint() {
+        return start;
+    }
+
+    public Endpoint endEndpoint() {
+        return end;
     }
 
     /**
      * Returns the required number of bases to be added to a start position in order to shift the position from
-     * <code>this</code> system to the <code>required</code> coordinate system.
+     * <code>this</code> system to the <code>required</code> endpoint type.
      *
-     * @param required coordinate system
+     * @param required endpoint
      * @return an integer in the range [-1, 0, 1]
      */
-    public int startDelta(CoordinateSystem required) {
-        return startDelta(this, required);
+    public int startDelta(Endpoint required) {
+        return startDelta(startEndpoint(), required);
+    }
+
+    /**
+     * Returns the required number of bases to be added to an end position in order to shift the position from
+     * <code>this</code> system to the <code>required</code> endpoint type.
+     *
+     * @param required endpoint
+     * @return an integer in the range [-1, 0, 1]
+     */
+    public int endDelta(Endpoint required) {
+        return endDelta(endEndpoint(), required);
     }
 }

--- a/src/main/java/org/monarchinitiative/variant/api/Endpoint.java
+++ b/src/main/java/org/monarchinitiative/variant/api/Endpoint.java
@@ -16,6 +16,14 @@ public enum Endpoint {
     /**
      * Closed endpoint <em>includes</em> the coordinate.
      */
-    CLOSED
+    CLOSED;
+
+    public boolean isOpen() {
+        return this == OPEN;
+    }
+
+    public boolean isClosed() {
+        return this == CLOSED;
+    }
 
 }

--- a/src/main/java/org/monarchinitiative/variant/api/GenomicComparators.java
+++ b/src/main/java/org/monarchinitiative/variant/api/GenomicComparators.java
@@ -7,6 +7,15 @@ import java.util.Comparator;
  */
 class GenomicComparators {
 
+    enum RegionNaturalOrderComparator implements Comparator<Region> {
+        INSTANCE;
+
+        @Override
+        public int compare(Region o1, Region o2) {
+            return Region.compare(o1, o2);
+        }
+    }
+
     enum GenomicRegionNaturalOrderComparator implements Comparator<GenomicRegion> {
         INSTANCE;
 

--- a/src/main/java/org/monarchinitiative/variant/api/ImprecisePosition.java
+++ b/src/main/java/org/monarchinitiative/variant/api/ImprecisePosition.java
@@ -24,10 +24,10 @@ class ImprecisePosition implements Position {
 
     @Override
     public Position invert(Contig contig, CoordinateSystem coordinateSystem) {
-        if (coordinateSystem == CoordinateSystem.ONE_BASED) {
-            return Position.of(contig.length() - pos + 1, confidenceInterval().invert());
-        }
-        return Position.of(contig.length() - pos, confidenceInterval().invert());
+        int adjustedContigLength = contig.length()
+                + CoordinateSystem.startDelta(Endpoint.OPEN, coordinateSystem.startEndpoint())
+                + CoordinateSystem.endDelta(Endpoint.CLOSED, coordinateSystem.endEndpoint());
+        return Position.of(adjustedContigLength - pos, confidenceInterval().invert());
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/Position.java
+++ b/src/main/java/org/monarchinitiative/variant/api/Position.java
@@ -22,7 +22,9 @@ public interface Position extends Comparable<Position> {
      * @param delta amount by which to shift the position. Positive inputs will increase the value of pos, negative decrease it.
      * @return a Position shifted by the provided delta
      */
-    Position shift(int delta);
+    default Position shift(int delta) {
+        return delta == 0 ? this : withPos(pos() + delta);
+    }
 
     /**
      * @return the numeric position
@@ -41,7 +43,9 @@ public interface Position extends Comparable<Position> {
     /**
      * @return true if this position is precise (CI = [0,0])
      */
-    boolean isPrecise();
+    default boolean isPrecise() {
+        return confidenceInterval().isPrecise();
+    }
 
     Position asPrecise();
 
@@ -54,6 +58,29 @@ public interface Position extends Comparable<Position> {
      * @return a new position at the opposite end of the {@link Contig} on which the current {@link Position} is located
      */
     Position invert(Contig contig, CoordinateSystem coordinateSystem);
+
+
+    default int distanceTo(Position position) {
+        return distanceTo(position.pos());
+    }
+
+    default int distanceTo(int pos) {
+        return pos - pos();
+    }
+
+    default int distanceTo(Region region) {
+        region = region.toOneBased();
+        return distanceTo(region.start(), region.end());
+    }
+
+    default int distanceTo(int start, int end) {
+        if (start <= pos() && pos() <= end)
+            return 0;
+
+        int s = start - pos();
+        int e = end - pos();
+        return Math.abs(s) < Math.abs(e) ? s : e;
+    }
 
     /**
      * Note: this class has a natural ordering that is inconsistent with equals.

--- a/src/main/java/org/monarchinitiative/variant/api/PrecisePosition.java
+++ b/src/main/java/org/monarchinitiative/variant/api/PrecisePosition.java
@@ -26,11 +26,6 @@ class PrecisePosition implements Position {
     }
 
     @Override
-    public Position shift(int delta) {
-        return delta == 0 ? this : new PrecisePosition(pos + delta);
-    }
-
-    @Override
     public int pos() {
         return pos;
     }
@@ -62,10 +57,10 @@ class PrecisePosition implements Position {
 
     @Override
     public Position invert(Contig contig, CoordinateSystem coordinateSystem) {
-        if (coordinateSystem == CoordinateSystem.ONE_BASED) {
-            return new PrecisePosition(contig.length() - pos + 1);
-        }
-        return new PrecisePosition(contig.length() - pos);
+        int adjustedContigLength = contig.length()
+                + CoordinateSystem.startDelta(Endpoint.OPEN, coordinateSystem.startEndpoint())
+                + CoordinateSystem.endDelta(Endpoint.CLOSED, coordinateSystem.endEndpoint());
+        return new PrecisePosition(adjustedContigLength - pos);
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/Region.java
+++ b/src/main/java/org/monarchinitiative/variant/api/Region.java
@@ -1,0 +1,97 @@
+package org.monarchinitiative.variant.api;
+
+import java.util.Comparator;
+
+public interface Region extends CoordinateSystemed<Region> {
+
+    /**
+     * @return start coordinate of the region
+     */
+    Position startPosition();
+
+    /**
+     * @return end coordinate of the region
+     */
+    Position endPosition();
+
+    /**
+     * @return start coordinate of the region
+     */
+    default int start() {
+        return startPosition().pos();
+    }
+
+    default int normalisedStart(Endpoint endpoint) {
+        return start() + coordinateSystem().startDelta(endpoint);
+    }
+
+    default Position normalisedStartPosition(Endpoint endpoint) {
+        return startPosition().shift(coordinateSystem().startDelta(endpoint));
+    }
+
+    /**
+     * @return end coordinate of the region
+     */
+    default int end() {
+        return endPosition().pos();
+    }
+
+    default int normalisedEnd(Endpoint endpoint) {
+        return end() + coordinateSystem().endDelta(endpoint);
+    }
+
+    default Position normalisedEndPosition(Endpoint endpoint) {
+        return endPosition().shift(coordinateSystem().endDelta(endpoint));
+    }
+
+    /**
+     * @param other chromosomal region
+     * @return true if the <code>other</code> region is fully contained within this region
+     */
+    default boolean contains(Region other) {
+        other = other.withCoordinateSystem(coordinateSystem());
+        return contains(other.start(), other.end());
+    }
+
+    default boolean contains(int start, int end) {
+        return start() <= start && end <= end();
+    }
+
+
+    default boolean contains(Position position) {
+        return contains(position.pos());
+    }
+
+    default boolean contains(int position) {
+        return normalisedStart(Endpoint.CLOSED) <= position && position <= normalisedEnd(Endpoint.CLOSED);
+    }
+
+
+    default boolean overlapsWith(Region other) {
+        other = other.withCoordinateSystem(coordinateSystem());
+        return overlapsWith(other.start(), other.end());
+    }
+
+    default boolean overlapsWith(int start, int end) {
+        return start() <= end && start <= end();
+    }
+
+
+    default int length() {
+        // the easiest way how to calculate length is to use half-open interval coordinates
+        return normalisedEnd(Endpoint.CLOSED) - normalisedStart(Endpoint.OPEN);
+    }
+
+    static Comparator<Region> naturalOrder() {
+        return GenomicComparators.RegionNaturalOrderComparator.INSTANCE;
+    }
+
+    static int compare(Region x, Region y) {
+        y = y.withCoordinateSystem(x.coordinateSystem());
+        int result = Integer.compare(x.start(), y.start());
+        if (result == 0) {
+            result = Integer.compare(x.end(), y.end());
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/monarchinitiative/variant/api/UnknownContig.java
+++ b/src/main/java/org/monarchinitiative/variant/api/UnknownContig.java
@@ -44,7 +44,7 @@ final class UnknownContig implements Contig {
 
     @Override
     public int length() {
-        return 1;
+        return 0;
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/UnresolvedBreakend.java
+++ b/src/main/java/org/monarchinitiative/variant/api/UnresolvedBreakend.java
@@ -42,8 +42,38 @@ final class UnresolvedBreakend implements Breakend {
     }
 
     @Override
-    public Position position() {
-        return POSITION;
+    public UnresolvedBreakend withPos(int pos) {
+        return this;
+    }
+
+    @Override
+    public int pos() {
+        return POSITION.pos();
+    }
+
+    @Override
+    public ConfidenceInterval confidenceInterval() {
+        return ConfidenceInterval.precise();
+    }
+
+    @Override
+    public UnresolvedBreakend asPrecise() {
+        return this;
+    }
+
+    @Override
+    public UnresolvedBreakend invert(Contig contig, CoordinateSystem coordinateSystem) {
+        return this;
+    }
+
+    @Override
+    public int minPos() {
+        return POSITION.minPos();
+    }
+
+    @Override
+    public int maxPos() {
+        return POSITION.maxPos();
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/Variant.java
+++ b/src/main/java/org/monarchinitiative/variant/api/Variant.java
@@ -38,6 +38,17 @@ public interface Variant extends GenomicRegion {
     Variant withStrand(Strand other);
 
     @Override
+    Variant withCoordinateSystem(CoordinateSystem coordinateSystem);
+
+    default Variant toZeroBased() {
+        return withCoordinateSystem(CoordinateSystem.ZERO_BASED);
+    }
+
+    default Variant toOneBased() {
+        return withCoordinateSystem(CoordinateSystem.ONE_BASED);
+    }
+
+    @Override
     default Variant toOppositeStrand() {
         return withStrand(strand().opposite());
     }

--- a/src/main/java/org/monarchinitiative/variant/api/impl/BreakendVariant.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/BreakendVariant.java
@@ -76,12 +76,12 @@ public final class BreakendVariant implements Variant, Breakended {
 
     @Override
     public Position startPosition() {
-        return left.position();
+        return left;
     }
 
     @Override
     public Position endPosition() {
-        return left.position();
+        return left;
     }
 
     /**

--- a/src/main/java/org/monarchinitiative/variant/api/impl/DefaultGenomicPosition.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/DefaultGenomicPosition.java
@@ -2,79 +2,22 @@ package org.monarchinitiative.variant.api.impl;
 
 import org.monarchinitiative.variant.api.*;
 
-import java.util.Objects;
-
 /**
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  * @author Daniel Danis <daniel.danis@jax.org>
  */
-public final class DefaultGenomicPosition implements GenomicPosition {
-
-    private final Contig contig;
-    private final Position position;
-    private final Strand strand;
+public final class DefaultGenomicPosition extends BaseGenomicPosition<DefaultGenomicPosition> {
 
     private DefaultGenomicPosition(Contig contig, Strand strand, Position position) {
-        if ((position.minPos() < 0)) {
-            throw new IllegalArgumentException("Cannot create genomic position " + position + " that extends beyond first contig base");
-        }
-        if (position.maxPos() > contig.length()) {
-            throw new IllegalArgumentException("Cannot create genomic position " + position + " that extends beyond contig end " + contig.length());
-        }
-
-        this.contig = contig;
-        this.position = position;
-        this.strand = strand;
+        super(contig, strand, position);
     }
 
-    public static GenomicPosition of(Contig contig, Strand strand, CoordinateSystem coordinateSystem, Position position) {
-        return new DefaultGenomicPosition(contig, strand, position.shift(coordinateSystem.startDelta(CoordinateSystem.ZERO_BASED)));
+    public static DefaultGenomicPosition of(Contig contig, Strand strand, Position position) {
+        return new DefaultGenomicPosition(contig, strand, position);
     }
 
     @Override
-    public Contig contig() {
-        return contig;
-    }
-
-    @Override
-    public Position position() {
-        return position;
-    }
-
-    @Override
-    public DefaultGenomicPosition withStrand(Strand other) {
-        if (strand == other) {
-            return this;
-        }
-        return new DefaultGenomicPosition(contig, other, position.invert(contig, CoordinateSystem.ZERO_BASED));
-    }
-
-    @Override
-    public Strand strand() {
-        return strand;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DefaultGenomicPosition that = (DefaultGenomicPosition) o;
-        return Objects.equals(contig, that.contig) &&
-                Objects.equals(position, that.position) &&
-                strand == that.strand;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(contig, position, strand);
-    }
-
-    @Override
-    public String toString() {
-        return "GenomicPosition{" +
-                "contig=" + contig +
-                ", position=" + position +
-                ", strand=" + strand +
-                '}';
+    protected DefaultGenomicPosition newPositionInstance(Contig contig, Strand strand, Position position) {
+        return new DefaultGenomicPosition(contig, strand, position);
     }
 }

--- a/src/main/java/org/monarchinitiative/variant/api/impl/PartialBreakend.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/PartialBreakend.java
@@ -8,36 +8,27 @@ import java.util.Objects;
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  * @author Daniel Danis <daniel.danis@jax.org>
  */
-public class PartialBreakend implements Breakend {
+public class PartialBreakend extends BaseGenomicPosition<PartialBreakend> implements Breakend {
 
-    private final Contig contig;
     private final String id;
-    private final Strand strand;
-    private final Position position;
 
     private PartialBreakend(Contig contig, String id, Strand strand, Position position) {
-        this.contig = Objects.requireNonNull(contig);
-        this.position = Objects.requireNonNull(position);
-        this.strand = Objects.requireNonNull(strand);
+        super(contig, strand, position);
         this.id = Objects.requireNonNull(id);
     }
 
     /**
-     * Create partial breakend from coordinates in {@link CoordinateSystem#ONE_BASED} system.
-     *
-     * Note that the returned breakend is always in {@link CoordinateSystem#ZERO_BASED}.
+     * Create partial breakend from a closed position coordinate, such as the start position of {@link CoordinateSystem#ONE_BASED}.
      */
     public static PartialBreakend oneBased(Contig contig, String id, Strand strand, Position position) {
-        return of(contig, id, strand, CoordinateSystem.ONE_BASED, position);
+        return of(contig, id, strand, position);
     }
 
     /**
-     * Create partial breakend from coordinates in {@link CoordinateSystem#ZERO_BASED} system.
-     *
-     * Note that the returned breakend is always in {@link CoordinateSystem#ZERO_BASED}.
+     * Create partial breakend from an open position coordinate, such as a start position in {@link CoordinateSystem#ZERO_BASED}.
      */
     public static PartialBreakend zeroBased(Contig contig, String id, Strand strand, Position position) {
-        return of(contig, id, strand, CoordinateSystem.ZERO_BASED, position);
+        return of(contig, id, strand, position.shift(1));
     }
 
     /**
@@ -45,23 +36,8 @@ public class PartialBreakend implements Breakend {
      *
      * Note that the returned breakend is always in {@link CoordinateSystem#ZERO_BASED}.
      */
-    public static PartialBreakend of(Contig contig, String id, Strand strand, CoordinateSystem coordinateSystem, Position position) {
-        return new PartialBreakend(contig, id, strand, position.shift(coordinateSystem.startDelta(CoordinateSystem.ZERO_BASED)));
-    }
-
-    @Override
-    public Contig contig() {
-        return contig;
-    }
-
-    @Override
-    public Position position() {
-        return position;
-    }
-
-    @Override
-    public Strand strand() {
-        return strand;
+    public static PartialBreakend of(Contig contig, String id, Strand strand, Position position) {
+        return new PartialBreakend(contig, id, strand, position);
     }
 
     @Override
@@ -70,37 +46,28 @@ public class PartialBreakend implements Breakend {
     }
 
     @Override
-    public PartialBreakend withStrand(Strand other) {
-        if (strand == other) {
-            return this;
-        }
-        Position pos = position.invert(contig, CoordinateSystem.ZERO_BASED); // GenomicPosition is always ZERO_BASED
-        return new PartialBreakend(contig, id, other, pos);
+    protected PartialBreakend newPositionInstance(Contig contig, Strand strand, Position position) {
+        return new PartialBreakend(contig, id, strand, position);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof PartialBreakend)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
         PartialBreakend that = (PartialBreakend) o;
-        return contig.equals(that.contig) &&
-                position.equals(that.position) &&
-                strand == that.strand &&
-                id.equals(that.id);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contig, position, strand, id);
+        return Objects.hash(super.hashCode(), id);
     }
 
     @Override
     public String toString() {
         return "PartialBreakend{" +
-                "contig=" + contig.id() +
-                ", id='" + id +
-                ", position=" + position +
-                ", strand=" + strand + '\'' +
-                '}';
+                "id='" + id + '\'' +
+                "} " + super.toString();
     }
 }

--- a/src/main/java/org/monarchinitiative/variant/api/impl/SequenceVariant.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/SequenceVariant.java
@@ -100,7 +100,7 @@ public final class SequenceVariant implements Variant {
         if (this.coordinateSystem == coordinateSystem) {
             return this;
         }
-        return new SequenceVariant(contig, id, strand, coordinateSystem, normalisedStartPosition(coordinateSystem), endPosition, ref, alt);
+        return new SequenceVariant(contig, id, strand, coordinateSystem, normalisedStartPosition(coordinateSystem.startEndpoint()), normalisedEndPosition(coordinateSystem.endEndpoint()), ref, alt);
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/impl/SymbolicVariant.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/SymbolicVariant.java
@@ -34,7 +34,7 @@ public final class SymbolicVariant implements Variant {
         this.startPosition = Objects.requireNonNull(startPosition);
         this.endPosition = Objects.requireNonNull(endPosition);
 
-        int startZeroBased = normalisedStartPosition(CoordinateSystem.ZERO_BASED).pos();
+        int startZeroBased = normalisedStart(Endpoint.OPEN);
         if (startZeroBased >= endPosition.pos()) {
             throw new IllegalArgumentException("start " + startZeroBased + " must be upstream of end " + endPosition.pos());
         }
@@ -126,11 +126,11 @@ public final class SymbolicVariant implements Variant {
     }
 
     @Override
-    public GenomicRegion withCoordinateSystem(CoordinateSystem coordinateSystem) {
+    public Variant withCoordinateSystem(CoordinateSystem coordinateSystem) {
         if (this.coordinateSystem == coordinateSystem) {
             return this;
         }
-        return new SymbolicVariant(contig, id, strand, coordinateSystem, normalisedStartPosition(coordinateSystem), endPosition, ref, alt, changeLength);
+        return new SymbolicVariant(contig, id, strand, coordinateSystem, normalisedStartPosition(coordinateSystem.startEndpoint()), normalisedEndPosition(coordinateSystem.endEndpoint()), ref, alt, changeLength);
     }
 
     @Override

--- a/src/main/java/org/monarchinitiative/variant/api/impl/VcfBreakendFormatter.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/VcfBreakendFormatter.java
@@ -46,7 +46,7 @@ public class VcfBreakendFormatter {
         }
 
         String mate = (rightStrand == Strand.POSITIVE)
-                ? '[' + contig + ':' + (pos + 1) + '['
+                ? '[' + contig + ':' + pos + '['
                 : ']' + contig + ':' + pos + ']';
 
         return leftStrand == Strand.POSITIVE

--- a/src/test/java/org/monarchinitiative/variant/api/CoordinateSystemTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/CoordinateSystemTest.java
@@ -27,13 +27,23 @@ public class CoordinateSystemTest {
 
     @ParameterizedTest
     @CsvSource({
-            "ONE_BASED, ONE_BASED, 0",
-            "ONE_BASED, ZERO_BASED, -1",
-            "ZERO_BASED, ZERO_BASED, 0",
-            "ZERO_BASED, ONE_BASED, 1"
+            " ONE_BASED,  CLOSED,   0",
+            " ONE_BASED,    OPEN,  -1",
+            "ZERO_BASED,    OPEN,   0",
+            "ZERO_BASED,  CLOSED,   1"
     })
-    public void startDelta(CoordinateSystem current, CoordinateSystem desired, int expected) {
+    public void startDelta(CoordinateSystem current, Endpoint desired, int expected) {
         assertThat(current.startDelta(desired), equalTo(expected));
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            " ONE_BASED,  CLOSED,   0",
+            " ONE_BASED,    OPEN,   1",
+            "ZERO_BASED,    OPEN,   1",
+            "ZERO_BASED,  CLOSED,   0"
+    })
+    public void endDelta(CoordinateSystem current, Endpoint desired, int expected) {
+        assertThat(current.endDelta(desired), equalTo(expected));
+    }
 }

--- a/src/test/java/org/monarchinitiative/variant/api/GenomicPositionTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/GenomicPositionTest.java
@@ -1,5 +1,6 @@
 package org.monarchinitiative.variant.api;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -14,23 +15,22 @@ public class GenomicPositionTest {
 
     @Test
     public void properties() {
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7, ConfidenceInterval.of(-1, 2)));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7, ConfidenceInterval.of(-1, 2)));
 
         assertThat(seven.contig(), equalTo(ctg1));
         assertThat(seven.contigId(), equalTo(1));
         assertThat(seven.contigName(), equalTo("1"));
-        assertThat(seven.position(), equalTo(Position.of(7, ConfidenceInterval.of(-1, 2))));
         assertThat(seven.pos(), equalTo(7));
-        assertThat(seven.ci(), equalTo(ConfidenceInterval.of(-1, 2)));
-        assertThat(seven.min(), equalTo(6));
-        assertThat(seven.max(), equalTo(9));
+        assertThat(seven.confidenceInterval(), equalTo(ConfidenceInterval.of(-1, 2)));
+        assertThat(seven.minPos(), equalTo(6));
+        assertThat(seven.maxPos(), equalTo(9));
         assertThat(seven.strand(), equalTo(Strand.POSITIVE));
     }
 
     @Test
     public void distanceToPosition() {
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7));
-        GenomicPosition three = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7));
+        GenomicPosition three = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3));
 
         assertThat(seven.distanceTo(three), equalTo(-4));
         assertThat(three.distanceTo(seven), equalTo(4));
@@ -39,77 +39,75 @@ public class GenomicPositionTest {
     @Test
     public void distanceToPositionWhenOnDifferentContig() {
         Contig ctg2 = TestContig.of(2, 20);
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7));
 
-        GenomicPosition other = GenomicPosition.zeroBased(ctg2, Strand.POSITIVE, Position.of(2));
+        GenomicPosition other = GenomicPosition.of(ctg2, Strand.POSITIVE, Position.of(2));
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> seven.distanceTo(other));
         assertThat(e.getMessage(), equalTo("Coordinates are on different chromosomes: 1 vs. 2"));
     }
 
     @Test
     public void distanceToRegion() {
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7));
-        GenomicPosition three = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7));
+        GenomicPosition three = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3));
 
-        GenomicRegion region = GenomicRegion.oneBased(ctg1, Strand.POSITIVE, Position.of(5), Position.of(6));
+        GenomicRegion region = GenomicRegion.oneBased(ctg1, Strand.POSITIVE, 5, 6);
 
         assertThat(seven.distanceTo(region), equalTo(-1));
         assertThat(three.distanceTo(region), equalTo(2));
 
-        GenomicRegion containing = GenomicRegion.oneBased(ctg1, Strand.POSITIVE, Position.of(2), Position.of(4));
+        GenomicRegion containing = GenomicRegion.oneBased(ctg1, Strand.POSITIVE, 2, 4);
         assertThat(three.distanceTo(containing), equalTo(0));
     }
 
     @Test
     public void distanceToRegionWhenOnDifferentContig() {
         Contig ctg2 = TestContig.of(2, 20);
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7));
 
-        GenomicRegion other = GenomicRegion.oneBased(ctg2, Strand.POSITIVE, Position.of(5), Position.of(6));
+        GenomicRegion other = GenomicRegion.oneBased(ctg2, Strand.POSITIVE, 5, 6);
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> seven.distanceTo(other));
         assertThat(e.getMessage(), equalTo("Coordinates are on different chromosomes: 1 vs. 2"));
     }
 
     @Test
     public void withStrand() {
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7, ConfidenceInterval.of(-1, 2)));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7, ConfidenceInterval.of(-1, 2)));
 
         assertThat(seven.withStrand(Strand.POSITIVE), is(sameInstance(seven)));
 
         GenomicPosition position = seven.withStrand(Strand.NEGATIVE);
-        assertThat(position.position(), equalTo(Position.of(3, ConfidenceInterval.of(-2, 1))));
+        assertThat(position.pos(), equalTo(4));
+        assertThat(position.confidenceInterval(), equalTo(ConfidenceInterval.of(-2, 1)));
         assertThat(position.strand(), equalTo(Strand.NEGATIVE));
     }
 
     @ParameterizedTest
     @CsvSource({
-            // source  pos   target     expected   pos
-            "POSITIVE, 3,   POSITIVE,   POSITIVE,   3",
-            "POSITIVE, 3,   NEGATIVE,   NEGATIVE,   7",
+            // source  pos   target     pos
+            "POSITIVE, 3,   POSITIVE,   3",
+            "POSITIVE, 3,   NEGATIVE,   8",
 
-            "NEGATIVE, 3,   POSITIVE,   POSITIVE,   7",
-            "NEGATIVE, 3,   NEGATIVE,   NEGATIVE,   3"
+            "NEGATIVE, 3,   POSITIVE,   8",
+            "NEGATIVE, 3,   NEGATIVE,   3"
             })
-    public void withStrand_strandConversions(Strand source, int pos, Strand target, Strand expected, int expectedPosition) {
-        GenomicPosition initial = GenomicPosition.zeroBased(ctg1, source, Position.of(pos));
+    public void withStrand_strandConversions(Strand source, int pos, Strand target, int expectedPosition) {
+        GenomicPosition initial = GenomicPosition.of(ctg1, source, Position.of(pos));
 
         GenomicPosition actual = initial.withStrand(target);
-        assertThat(actual.strand(), equalTo(expected));
+        assertThat(actual.strand(), equalTo(target));
         assertThat(actual.pos(), equalTo(expectedPosition));
     }
 
     @ParameterizedTest
     @CsvSource({
-            // strand  coords      pos  expected coords  start end
-            "POSITIVE, ZERO_BASED, 3,   ZERO_BASED,   3, 4",
-            "NEGATIVE, ZERO_BASED, 3,   ZERO_BASED,   3, 4",
-
-            "POSITIVE, ONE_BASED, 3,   ZERO_BASED,   2, 3",
-            "NEGATIVE, ONE_BASED, 3,   ZERO_BASED,   2, 3",
+            // strand  pos  expected coords  start end
+            "POSITIVE, 3,   ZERO_BASED,   2, 3",
+            "NEGATIVE, 3,   ZERO_BASED,   2, 3",
     })
-    public void toRegion(Strand strand, CoordinateSystem initCoords, int initPos, CoordinateSystem exptCoords, int exptStart, int exptEnd) {
+    public void toRegion(Strand strand, int initPos, CoordinateSystem exptCoords, int exptStart, int exptEnd) {
         // a position is turned into a region of length 1
-        GenomicPosition position = GenomicPosition.of(ctg1, strand, initCoords, Position.of(initPos));
+        GenomicPosition position = GenomicPosition.of(ctg1, strand, Position.of(initPos));
         GenomicRegion expected = GenomicRegion.of(ctg1, strand, exptCoords, Position.of(exptStart), Position.of(exptEnd));
         assertThat(position.toRegion(), equalTo(expected));
     }
@@ -121,18 +119,18 @@ public class GenomicPositionTest {
     })
     public void toRegion_singlePadding(int pos, int padding,
                                           int expectedStart, int expectedEnd) {
-        GenomicRegion actual = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(pos)).toRegion(padding);
+        GenomicRegion actual = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(pos)).toRegion(padding);
         GenomicRegion expected = GenomicRegion.of(ctg1, Strand.POSITIVE, CoordinateSystem.ZERO_BASED, Position.of(expectedStart), Position.of(expectedEnd));
         assertThat(actual, equalTo(expected));
     }
 
     @Test
     public void toRegion_singleNegativePadding() {
-        GenomicPosition three = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3, ConfidenceInterval.of(-2, 3)));
+        GenomicPosition three = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3, ConfidenceInterval.of(-2, 3)));
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> three.toRegion(-1));
         assertThat(e.getMessage(), equalTo("Cannot apply negative padding: -1"));
 
-        GenomicPosition seven = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(7, ConfidenceInterval.of(-1, 2)));
+        GenomicPosition seven = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(7, ConfidenceInterval.of(-1, 2)));
         e = assertThrows(IllegalArgumentException.class, () -> seven.toRegion(-1));
         assertThat(e.getMessage(), equalTo("Cannot apply negative padding: -1"));
     }
@@ -149,7 +147,7 @@ public class GenomicPositionTest {
     public void toRegion_upDownPadding(int pos,
                                           int upstream, int downstream,
                                           int expectedStart, int expectedEnd) {
-        GenomicRegion actual = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(pos)).toRegion(upstream, downstream);
+        GenomicRegion actual = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(pos)).toRegion(upstream, downstream);
         GenomicRegion expected = GenomicRegion.of(ctg1, Strand.POSITIVE, CoordinateSystem.ZERO_BASED, Position.of(expectedStart), Position.of(expectedEnd));
         assertThat(actual, equalTo(expected));
     }
@@ -162,7 +160,7 @@ public class GenomicPositionTest {
             "2,  2,  1"
     })
     public void toRegion_illegalPadding(int pos, int upstream, int downstream) {
-        GenomicPosition position = GenomicPosition.oneBased(ctg1, Strand.POSITIVE, Position.of(pos));
+        GenomicPosition position = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(pos));
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> position.toRegion(upstream, downstream));
         assertThat(e.getMessage(), equalTo("Cannot apply negative padding: " + upstream + ", " + downstream));
     }
@@ -173,9 +171,9 @@ public class GenomicPositionTest {
         Contig ctg2 = TestContig.of(2, 10);
         Contig ctg3 = TestContig.of(3, 10);
 
-        GenomicPosition two = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3));
-        GenomicPosition three = GenomicPosition.zeroBased(ctg2, Strand.POSITIVE, Position.of(3));
-        GenomicPosition four = GenomicPosition.zeroBased(ctg3, Strand.POSITIVE, Position.of(3));
+        GenomicPosition two = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3));
+        GenomicPosition three = GenomicPosition.of(ctg2, Strand.POSITIVE, Position.of(3));
+        GenomicPosition four = GenomicPosition.of(ctg3, Strand.POSITIVE, Position.of(3));
 
         assertThat(GenomicPosition.compare(three, two), equalTo(1));
         assertThat(GenomicPosition.compare(three, three), equalTo(0));
@@ -188,9 +186,9 @@ public class GenomicPositionTest {
             "3,  0",
             "4, -1"})
     public void compareWhenDifferingPositions(int pos, int expected) {
-        GenomicPosition three = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3));
+        GenomicPosition three = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3));
 
-        GenomicPosition gp = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(pos));
+        GenomicPosition gp = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(pos));
 
         assertThat(GenomicPosition.compare(three, gp), equalTo(expected));
     }
@@ -206,8 +204,8 @@ public class GenomicPositionTest {
             "3, 3,   false",
             "3, 4,   true"})
     public void isUpstreamOfPosition(int a, int b, boolean expected) {
-        GenomicPosition aPos = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(a));
-        GenomicPosition bPos = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(b));
+        GenomicPosition aPos = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(a));
+        GenomicPosition bPos = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(b));
         assertThat(aPos.isUpstreamOf(bPos), equalTo(expected));
     }
 
@@ -216,18 +214,18 @@ public class GenomicPositionTest {
             "3,  ONE_BASED, 2, 2,   false",
             "3,  ONE_BASED, 2, 3,   false",
             "3,  ONE_BASED, 3, 3,   false",
-            "3,  ONE_BASED, 4, 4,   false",
+            "3,  ONE_BASED, 4, 4,   true",
             "3,  ONE_BASED, 5, 5,   true",
 
             "3,  ZERO_BASED, 1, 2,   false",
             "3,  ZERO_BASED, 2, 3,   false",
-            "3,  ZERO_BASED, 3, 4,   false",
+            "3,  ZERO_BASED, 3, 4,   true",
             "3,  ZERO_BASED, 4, 5,   true"
     })
     public void isUpstreamOfRegion(int pos,
                                    CoordinateSystem coordinateSystem, int start, int end,
                                    boolean expected) {
-        GenomicPosition position = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(pos));
+        GenomicPosition position = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(pos));
         GenomicRegion region = GenomicRegion.of(ctg1, Strand.POSITIVE, coordinateSystem, Position.of(start), Position.of(end));
         assertThat(position.isUpstreamOf(region), equalTo(expected));
     }
@@ -239,8 +237,8 @@ public class GenomicPositionTest {
             "3,   false",
             "4,   false"})
     public void isDownstreamOfPosition(int pos, boolean expected) {
-        GenomicPosition three = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3));
-        GenomicPosition gp = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(pos));
+        GenomicPosition three = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3));
+        GenomicPosition gp = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(pos));
         assertThat(three.isDownstreamOf(gp), equalTo(expected));
     }
 
@@ -251,8 +249,8 @@ public class GenomicPositionTest {
             "4,4,false",
             "2,4,false"})
     public void isDownstreamOfRegion(int start, int end, boolean expected) {
-        GenomicPosition three = GenomicPosition.zeroBased(ctg1, Strand.POSITIVE, Position.of(3));
-        GenomicRegion region = GenomicRegion.oneBased(ctg1, Strand.POSITIVE, Position.of(start), Position.of(end));
+        GenomicPosition three = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(3));
+        GenomicRegion region = GenomicRegion.oneBased(ctg1, Strand.POSITIVE, start, end);
         assertThat(three.isDownstreamOf(region), equalTo(expected));
     }
 
@@ -265,13 +263,14 @@ public class GenomicPositionTest {
 
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "0, ZERO_BASED,   1",
-            "1, ONE_BASED,    1",
-    })
-    public void posOneBased(int position, CoordinateSystem coordinateSystem, int expected) {
-        GenomicPosition pos = GenomicPosition.of(ctg1, Strand.POSITIVE, coordinateSystem, Position.of(position));
-        assertThat(pos.posOneBased(), equalTo(expected));
-    }
+//    TODO - candidate for removal, I think we should remove the oneBased/zeroBased positions
+//    @ParameterizedTest
+//    @CsvSource({
+//            "0, ZERO_BASED,   1",
+//            "1, ONE_BASED,    1",
+//    })
+//    public void posOneBased(int position, CoordinateSystem coordinateSystem, int expected) {
+//        GenomicPosition pos = GenomicPosition.of(ctg1, Strand.POSITIVE, Position.of(position, ));
+//        assertThat(pos.posOneBased(), equalTo(expected));
+//    }
 }

--- a/src/test/java/org/monarchinitiative/variant/api/GenomicRegionTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/GenomicRegionTest.java
@@ -15,43 +15,43 @@ import static org.hamcrest.Matchers.sameInstance;
 public class GenomicRegionTest {
 
 
-    private final Contig chr1 = new TestContig(1, 5);
+    private final Contig chr1 = TestContig.of(1, 5);
 
     @Test
     public void oneBasedSingleBase() {
-        GenomicRegion instance = GenomicRegion.oneBased(chr1, Strand.POSITIVE, Position.of(1), Position.of(1));
+        GenomicRegion instance = GenomicRegion.oneBased(chr1, Strand.POSITIVE, 1, 1);
         assertThat(instance.start(), equalTo(1));
         assertThat(instance.end(), equalTo(1));
         assertThat(instance.length(), equalTo(1));
-        assertThat(instance.toOppositeStrand(), equalTo(DefaultGenomicRegion.oneBased(chr1, Strand.NEGATIVE, Position.of(5), Position.of(5))));
-        assertThat(instance.toOppositeStrand().toZeroBased(), equalTo(DefaultGenomicRegion.zeroBased(chr1, Strand.NEGATIVE, Position.of(4), Position.of(5))));
+        assertThat(instance.toOppositeStrand(), equalTo(GenomicRegion.oneBased(chr1, Strand.NEGATIVE, 5, 5)));
+        assertThat(instance.toOppositeStrand().toZeroBased(), equalTo(GenomicRegion.zeroBased(chr1, Strand.NEGATIVE, 4, 5)));
     }
 
     @Test
     public void zeroBasedSingleBase() {
-        GenomicRegion instance = GenomicRegion.zeroBased(chr1, Strand.POSITIVE, Position.of(0), Position.of(1));
+        GenomicRegion instance = GenomicRegion.zeroBased(chr1, Strand.POSITIVE, 0, 1);
         assertThat(instance.start(), equalTo(0));
         assertThat(instance.end(), equalTo(1));
         assertThat(instance.length(), equalTo(1));
-        assertThat(instance.toOppositeStrand(), equalTo(DefaultGenomicRegion.zeroBased(chr1, Strand.NEGATIVE, Position.of(4), Position.of(5))));
+        assertThat(instance.toOppositeStrand(), equalTo(GenomicRegion.zeroBased(chr1, Strand.NEGATIVE, 4, 5)));
     }
 
     @Test
     public void oneBasedMultiBase() {
-        GenomicRegion instance = GenomicRegion.oneBased(chr1, Strand.POSITIVE, Position.of(1), Position.of(2));
+        GenomicRegion instance = GenomicRegion.oneBased(chr1, Strand.POSITIVE, 1, 2);
         assertThat(instance.start(), equalTo(1));
         assertThat(instance.end(), equalTo(2));
         assertThat(instance.length(), equalTo(2));
-        assertThat(instance.toOppositeStrand(), equalTo(DefaultGenomicRegion.oneBased(chr1, Strand.NEGATIVE, Position.of(4), Position.of(5))));
+        assertThat(instance.toOppositeStrand(), equalTo(GenomicRegion.oneBased(chr1, Strand.NEGATIVE, Position.of(4), Position.of(5))));
     }
 
     @Test
     public void zeroBasedMultiBase() {
-        GenomicRegion instance = GenomicRegion.zeroBased(chr1, Strand.POSITIVE, Position.of(0), Position.of(2));
+        GenomicRegion instance = GenomicRegion.zeroBased(chr1, Strand.POSITIVE, 0, 2);
         assertThat(instance.start(), equalTo(0));
         assertThat(instance.end(), equalTo(2));
         assertThat(instance.length(), equalTo(2));
-        assertThat(instance.toOppositeStrand(), equalTo(DefaultGenomicRegion.zeroBased(chr1, Strand.NEGATIVE, Position.of(3), Position.of(5))));
+        assertThat(instance.toOppositeStrand(), equalTo(GenomicRegion.zeroBased(chr1, Strand.NEGATIVE, 3, 5)));
     }
 
     @Test
@@ -62,9 +62,10 @@ public class GenomicRegionTest {
 
     @ParameterizedTest
     @CsvSource({
-            //
-            "ONE_BASED,  1, 2,     0",
-            "ZERO_BASED, 1, 2,     1"
+            "ONE_BASED,  1, 2,     1",
+            "ZERO_BASED, 1, 2,     1",
+            "RIGHT_OPEN, 1, 2,     1",
+            "FULLY_OPEN, 1, 2,     1",
     })
     public void startGenomicPosition(CoordinateSystem coordinateSystem, int start, int end, int expected) {
         Position startPos = Position.of(start);
@@ -95,19 +96,26 @@ public class GenomicRegionTest {
     @ParameterizedTest
     @CsvSource({
             // region            pos
-            "ZERO_BASED, 0, 1,   0,   true",
-            "ZERO_BASED, 1, 2,   1,   true",
-            "ZERO_BASED, 1, 2,   2,   false",
+            "FULLY_OPEN, 0, 2,   2,   false",
+            "ZERO_BASED, 0, 1,   2,   false",
+            "RIGHT_OPEN, 1, 2,   2,   false",
+            "ONE_BASED,  1, 1,   2,   false",
 
-            "ONE_BASED, 1, 1,    0,   true",
-            "ONE_BASED, 1, 1,    1,   false",
-            "ONE_BASED, 1, 2,    1,   true",
-            "ONE_BASED, 1, 2,    2,   false",
+            "FULLY_OPEN, 1, 3,   2,   true",
+            "ZERO_BASED, 1, 2,   2,   true",
+            "RIGHT_OPEN, 2, 3,   2,   true",
+            "ONE_BASED,  2, 2,   2,   true",
+
+            "FULLY_OPEN, 2, 4,   2,   false",
+            "ZERO_BASED, 2, 3,   2,   false",
+            "RIGHT_OPEN, 3, 4,   2,   false",
+            "ONE_BASED,  3, 3,   2,   false",
     })
-    public void containsPosition(CoordinateSystem coordinateSystem,int start, int end,
-                                 int position, boolean expected) {
+    public void containsPosition(CoordinateSystem coordinateSystem, int start, int end,
+                                 int position,
+                                 boolean expected) {
         GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, coordinateSystem, Position.of(start), Position.of(end));
-        GenomicPosition pos = GenomicPosition.zeroBased(chr1, Strand.POSITIVE, Position.of(position));
+        GenomicPosition pos = GenomicPosition.of(chr1, Strand.POSITIVE, Position.of(position));
 
         assertThat(region.contains(pos), equalTo(expected));
     }
@@ -117,7 +125,7 @@ public class GenomicRegionTest {
         GenomicRegion oneToThree = GenomicRegion.oneBased(chr1, Strand.POSITIVE, Position.of(1), Position.of(3));
 
         Contig ctg2 = TestContig.of(2, 200);
-        GenomicPosition other = GenomicPosition.zeroBased(ctg2, Strand.POSITIVE, Position.of(2));
+        GenomicPosition other = GenomicPosition.of(ctg2, Strand.POSITIVE, Position.of(2));
         assertThat(oneToThree.contains(other), equalTo(false));
     }
 
@@ -202,21 +210,46 @@ public class GenomicRegionTest {
         assertThat(oneToThree.contains(other), equalTo(false));
     }
 
+    @Test
+    public void withStrand_emptyRegion() {
+        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, CoordinateSystem.FULLY_OPEN, Position.of(0), Position.of(1));
+
+        GenomicRegion negative = region.withStrand(Strand.NEGATIVE);
+        assertThat(negative.startPosition(), equalTo(Position.of(5)));
+        assertThat(negative.endPosition(), equalTo(Position.of(6)));
+        assertThat(negative.coordinateSystem(), equalTo(CoordinateSystem.FULLY_OPEN));
+    }
+
     @ParameterizedTest
     @CsvSource({
-            // source start  end    target      expected    pos
-            "POSITIVE,    3, 5,     POSITIVE,   POSITIVE,   3, 5",
-            "POSITIVE,    3, 5,     NEGATIVE,   NEGATIVE,   1, 3",
+            // we test 2-bp-long region that spans the bases 3-4 of the imaginary contig with length 5
+            // source     start      end       target   start  end
+            "POSITIVE,    FULLY_OPEN, 2,  5,   NEGATIVE,    1, 4",
+            "POSITIVE,    ZERO_BASED, 2,  4,   NEGATIVE,    1, 3",
+            "POSITIVE,    RIGHT_OPEN, 3,  5,   NEGATIVE,    2, 4",
+            "POSITIVE,    ONE_BASED,  3,  4,   NEGATIVE,    2, 3",
+            "NEGATIVE,    FULLY_OPEN, 1,  4,   POSITIVE,    2, 5",
+            "NEGATIVE,    ZERO_BASED, 1,  3,   POSITIVE,    2, 4",
+            "NEGATIVE,    RIGHT_OPEN, 2,  4,   POSITIVE,    3, 5",
+            "NEGATIVE,    ONE_BASED,  2,  3,   POSITIVE,    3, 4",
 
-            "NEGATIVE,    3, 5,     POSITIVE,   POSITIVE,   1, 3",
-            "NEGATIVE,    3, 5,     NEGATIVE,   NEGATIVE,   3, 5"
+            // converting to the same strand preserves the coordinates
+            "POSITIVE,    FULLY_OPEN, 2,  5,   POSITIVE,    2, 5",
+            "POSITIVE,    ZERO_BASED, 2,  4,   POSITIVE,    2, 4",
+            "POSITIVE,    RIGHT_OPEN, 3,  5,   POSITIVE,    3, 5",
+            "POSITIVE,    ONE_BASED,  3,  4,   POSITIVE,    3, 4",
+            "NEGATIVE,    FULLY_OPEN, 1,  4,   NEGATIVE,    1, 4",
+            "NEGATIVE,    ZERO_BASED, 1,  3,   NEGATIVE,    1, 3",
+            "NEGATIVE,    RIGHT_OPEN, 2,  4,   NEGATIVE,    2, 4",
+            "NEGATIVE,    ONE_BASED,  2,  3,   NEGATIVE,    2, 3",
     })
-    public void withStrand_strandConversions(Strand source, int start, int end,
-                                             Strand target, Strand expected, int exptStart, int exptEnd) {
-        GenomicRegion initial = GenomicRegion.oneBased(chr1, source, Position.of(start), Position.of(end));
+    public void withStrand_strandConversions(Strand source, CoordinateSystem coordinateSystem, int start, int end,
+                                             Strand target,
+                                             int exptStart, int exptEnd) {
+        GenomicRegion initial = GenomicRegion.of(chr1, source, coordinateSystem, Position.of(start), Position.of(end));
 
         GenomicRegion actual = initial.withStrand(target);
-        assertThat(actual.strand(), equalTo(expected));
+        assertThat(actual.strand(), equalTo(target));
         assertThat(actual.start(), equalTo(exptStart));
         assertThat(actual.end(), equalTo(exptEnd));
         assertThat(actual.coordinateSystem(), equalTo(initial.coordinateSystem()));
@@ -257,40 +290,101 @@ public class GenomicRegionTest {
         assertThat(actual, equalTo(expected));
     }
 
+//    TODO - candidate for removal, not valid anymore
+//    @ParameterizedTest
+//    @CsvSource({
+//            "ONE_BASED,  3, 3,     1",
+//            "ZERO_BASED, 2, 3,     1",
+//            "ONE_BASED,  2, 3,     2",
+//            "ZERO_BASED, 1, 3,     2",
+//            "ONE_BASED,  1, 3,     3"
+//    })
+//    public void startEndDifferenceEqualToRegionLength(CoordinateSystem coordinateSystem, int start, int end,
+//                                                      int regionLength) {
+//        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, coordinateSystem, Position.of(start), Position.of(end));
+//
+//        GenomicPosition regionStart = region.startGenomicPosition();
+//        GenomicPosition regionEnd = region.endGenomicPosition();
+//
+//        assertThat(regionStart.distanceTo(regionEnd), equalTo(region.length()));
+//        assertThat(regionEnd.distanceTo(regionStart), equalTo(-regionLength));
+//    }
+
     @ParameterizedTest
     @CsvSource({
-            "ONE_BASED,  3, 3,     1",
-            "ZERO_BASED, 2, 3,     1",
-            "ONE_BASED,  2, 3,     2",
-            "ZERO_BASED, 1, 3,     2",
-            "ONE_BASED,  1, 3,     3"
+            "ONE_BASED,   2, 3,    CLOSED,   2",
+            "ONE_BASED,   2, 3,      OPEN,   1",
+            "ZERO_BASED,  2, 3,    CLOSED,   3",
+            "ZERO_BASED,  2, 3,      OPEN,   2",
+            "RIGHT_OPEN,  2, 3,    CLOSED,   2",
+            "RIGHT_OPEN,  2, 3,      OPEN,   1",
+            "FULLY_OPEN,  2, 3,    CLOSED,   3",
+            "FULLY_OPEN,  2, 3,      OPEN,   2",
     })
-    public void startEndDifferenceEqualToRegionLength(CoordinateSystem coordinateSystem, int start, int end,
-                                                      int regionLength) {
-        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, coordinateSystem, Position.of(start), Position.of(end));
+    public void normalizeStartPosition(CoordinateSystem coordinateSystem, int startPos, int endPos,
+                                       Endpoint targetEndpoint, int expectedStart) {
+        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, coordinateSystem, Position.of(startPos), Position.of(endPos));
 
-        GenomicPosition regionStart = region.startGenomicPosition();
-        GenomicPosition regionEnd = region.endGenomicPosition();
+        Position normalisedStartPosition = region.normalisedStartPosition(targetEndpoint);
+        assertThat(normalisedStartPosition, equalTo(Position.of(expectedStart)));
 
-        assertThat(regionStart.distanceTo(regionEnd), equalTo(regionLength));
-        assertThat(regionEnd.distanceTo(regionStart), equalTo(-regionLength));
+        if (targetEndpoint.equals(coordinateSystem.startEndpoint()))
+            assertThat(normalisedStartPosition, sameInstance(region.startPosition()));
     }
 
     @ParameterizedTest
     @CsvSource({
-            "ONE_BASED,   2, 3,   ONE_BASED,   2",
-            "ONE_BASED,   2, 3,   ZERO_BASED,  1",
-            "ZERO_BASED,  2, 3,   ONE_BASED,   3",
-            "ZERO_BASED,  2, 3,   ZERO_BASED,  2",
+            "ONE_BASED,   2, 3,   CLOSED,   3",
+            "ONE_BASED,   2, 3,     OPEN,   4",
+            "ZERO_BASED,  2, 3,   CLOSED,   3",
+            "ZERO_BASED,  2, 3,     OPEN,   4",
+            "RIGHT_OPEN,  2, 3,   CLOSED,   2",
+            "RIGHT_OPEN,  2, 3,     OPEN,   3",
+            "FULLY_OPEN,  2, 3,   CLOSED,   2",
+            "FULLY_OPEN,  2, 3,     OPEN,   3",
     })
-    public void normalizeStartPosition(CoordinateSystem coordinateSystem, int startPos, int endPos,
-                                       CoordinateSystem targetSystem, int expectedStart) {
-        Position startPosition = Position.of(startPos);
-        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, coordinateSystem, startPosition, Position.of(endPos));
+    public void normalizeEndPosition(CoordinateSystem coordinateSystem, int startPos, int endPos,
+                                     Endpoint targetEndpoint, int expectedEnd) {
+        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, coordinateSystem, Position.of(startPos), Position.of(endPos));
 
-        assertThat(region.normalisedStartPosition(targetSystem), equalTo(Position.of(expectedStart)));
+        Position normalisedEndPosition = region.normalisedEndPosition(targetEndpoint);
+        assertThat(normalisedEndPosition, equalTo(Position.of(expectedEnd)));
 
-        if (targetSystem.isZeroBased() && coordinateSystem.isZeroBased())
-            assertThat(region.normalisedStartPosition(targetSystem), sameInstance(startPosition));
+        if (targetEndpoint.equals(coordinateSystem.endEndpoint()))
+            assertThat(normalisedEndPosition, sameInstance(region.endPosition()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "FULLY_OPEN, 1, 4,    ZERO_BASED, 1, 3",
+            "FULLY_OPEN, 1, 4,     ONE_BASED, 2, 3",
+            "FULLY_OPEN, 1, 4,    FULLY_OPEN, 1, 4",
+            "FULLY_OPEN, 1, 4,    RIGHT_OPEN, 2, 4",
+
+            "RIGHT_OPEN, 2, 4,    ZERO_BASED, 1, 3",
+            "RIGHT_OPEN, 2, 4,     ONE_BASED, 2, 3",
+            "RIGHT_OPEN, 2, 4,    FULLY_OPEN, 1, 4",
+            "RIGHT_OPEN, 2, 4,    RIGHT_OPEN, 2, 4",
+
+            "ZERO_BASED, 1, 3,    ZERO_BASED, 1, 3",
+            "ZERO_BASED, 1, 3,     ONE_BASED, 2, 3",
+            "ZERO_BASED, 1, 3,    FULLY_OPEN, 1, 4",
+            "ZERO_BASED, 1, 3,    RIGHT_OPEN, 2, 4",
+
+            " ONE_BASED, 2, 3,    ZERO_BASED, 1, 3",
+            " ONE_BASED, 2, 3,     ONE_BASED, 2, 3",
+            " ONE_BASED, 2, 3,    FULLY_OPEN, 1, 4",
+            " ONE_BASED, 2, 3,    RIGHT_OPEN, 2, 4",
+    })
+    public void withCoordinateSystem(CoordinateSystem source, int start, int end,
+                                     CoordinateSystem target, int targetStart, int targetEnd) {
+
+        GenomicRegion region = GenomicRegion.of(chr1, Strand.POSITIVE, source, start, end);
+
+        GenomicRegion other = region.withCoordinateSystem(target);
+        assertThat(other.start(), equalTo(targetStart));
+        assertThat(other.coordinateSystem().startEndpoint(), equalTo(target.startEndpoint()));
+        assertThat(other.end(), equalTo(targetEnd));
+        assertThat(other.coordinateSystem().endEndpoint(), equalTo(target.endEndpoint()));
     }
 }

--- a/src/test/java/org/monarchinitiative/variant/api/PositionTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/PositionTest.java
@@ -129,13 +129,13 @@ public class PositionTest {
 
     @ParameterizedTest
     @CsvSource({
-            "1, ONE_BASED, 100",
-            "0, ZERO_BASED, 100",
-            "100, ZERO_BASED, 0",
-            "100, ONE_BASED, 1",
+            "1,  5",
+            "2,  4",
+            "5,  1",
     })
-    public void invert(int pos, CoordinateSystem coordinateSystem, int expected) {
-        Contig contig = TestContig.of(1, 100);
-        assertThat(Position.of(pos).invert(contig, coordinateSystem), equalTo(Position.of(expected)));
+    public void invert(int pos, int expected) {
+        Contig contig = TestContig.of(1, 5);
+        CoordinateSystem any = CoordinateSystem.FULLY_OPEN;
+        assertThat(Position.of(pos).invert(contig, any), equalTo(Position.of(expected)));
     }
 }

--- a/src/test/java/org/monarchinitiative/variant/api/RegionTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/RegionTest.java
@@ -1,0 +1,104 @@
+package org.monarchinitiative.variant.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RegionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "ONE_BASED, 3, 3,   FULLY_OPEN, 1, 3,  false",
+            "ONE_BASED, 3, 3,   ZERO_BASED, 1, 2,  false",
+            "ONE_BASED, 3, 3,   RIGHT_OPEN, 2, 3,  false",
+            "ONE_BASED, 3, 3,    ONE_BASED, 2, 2,  false",
+
+            "ONE_BASED, 3, 3,   FULLY_OPEN, 2, 4,  true",
+            "ONE_BASED, 3, 3,   ZERO_BASED, 2, 3,  true",
+            "ONE_BASED, 3, 3,   RIGHT_OPEN, 3, 4,  true",
+            "ONE_BASED, 3, 3,    ONE_BASED, 3, 3,  true",
+
+            "ONE_BASED, 3, 3,   FULLY_OPEN, 3, 5,  false",
+            "ONE_BASED, 3, 3,   ZERO_BASED, 3, 4,  false",
+            "ONE_BASED, 3, 3,   RIGHT_OPEN, 4, 5,  false",
+            "ONE_BASED, 3, 3,    ONE_BASED, 4, 4,  false",
+
+            "ONE_BASED, 3, 4,    ONE_BASED, 2, 3,  false",
+            "ONE_BASED, 3, 4,    ONE_BASED, 3, 4,  true",
+            "ONE_BASED, 3, 4,    ONE_BASED, 4, 5,  false",
+    })
+    public void contains_region(CoordinateSystem coordinateSystem, int start, int end,
+                                CoordinateSystem queryCoordinateSystem, int queryStart, int queryEnd,
+                                boolean expected) {
+        TestRegion region = TestRegion.of(coordinateSystem, start, end);
+        TestRegion query = TestRegion.of(queryCoordinateSystem, queryStart, queryEnd);
+
+        assertThat(region.contains(query), equalTo(expected));
+    }
+
+
+    @ParameterizedTest
+    @CsvSource({
+            "FULLY_OPEN, 2, 4,   2, false",
+            "FULLY_OPEN, 2, 4,   3, true",
+            "FULLY_OPEN, 2, 4,   4, false",
+
+            "ZERO_BASED, 2, 3,   2, false",
+            "ZERO_BASED, 2, 3,   3, true",
+            "ZERO_BASED, 2, 3,   4, false",
+
+            "RIGHT_OPEN, 3, 4,   2, false",
+            "RIGHT_OPEN, 3, 4,   3, true",
+            "RIGHT_OPEN, 3, 4,   4, false",
+
+            " ONE_BASED, 3, 3,   2, false",
+            " ONE_BASED, 3, 3,   3, true",
+            " ONE_BASED, 3, 3,   4, false",
+    })
+    public void contains_position(CoordinateSystem coordinateSystem, int start, int end,
+                                  int pos, boolean expected) {
+        TestRegion region = TestRegion.of(coordinateSystem, start, end);
+        Position query = Position.of(pos);
+
+        assertThat(region.contains(query), equalTo(expected));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "ONE_BASED, 3, 4,   ONE_BASED, 1, 2,  false",
+            "ONE_BASED, 3, 4,   ONE_BASED, 2, 3,  true",
+            "ONE_BASED, 3, 4,   ONE_BASED, 3, 4,  true",
+            "ONE_BASED, 3, 4,   ONE_BASED, 4, 5,  true",
+            "ONE_BASED, 3, 4,   ONE_BASED, 5, 5,  false",
+    })
+    public void overlapsWith(CoordinateSystem coordinateSystem, int start, int end,
+                             CoordinateSystem queryCoordinateSystem, int queryStart, int queryEnd,
+                             boolean expected) {
+        TestRegion region = TestRegion.of(coordinateSystem, start, end);
+        TestRegion query = TestRegion.of(queryCoordinateSystem, queryStart, queryEnd);
+
+        assertThat(region.overlapsWith(query), equalTo(expected));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "FULLY_OPEN, 1, 2,   0",
+            "ZERO_BASED, 2, 2,   0",
+            "RIGHT_OPEN, 2, 2,   0",
+            " ONE_BASED, 2, 1,   0",
+
+            "FULLY_OPEN, 1, 3,   1",
+            "ZERO_BASED, 1, 2,   1",
+            "RIGHT_OPEN, 2, 3,   1",
+            " ONE_BASED, 2, 2,   1",
+
+            " ONE_BASED, 2, 3,   2",
+            " ONE_BASED, 2, 4,   3",
+    })
+    public void length(CoordinateSystem coordinateSystem, int start, int end, int expected) {
+        assertThat(TestRegion.of(coordinateSystem,start, end).length(), equalTo(expected));
+    }
+}

--- a/src/test/java/org/monarchinitiative/variant/api/TestRegion.java
+++ b/src/test/java/org/monarchinitiative/variant/api/TestRegion.java
@@ -1,0 +1,61 @@
+package org.monarchinitiative.variant.api;
+
+import java.util.Objects;
+
+class TestRegion implements Region {
+
+    private final Position start, end;
+    private final CoordinateSystem coordinateSystem;
+
+    static TestRegion of(CoordinateSystem coordinateSystem, int start, int end) {
+        return new TestRegion(coordinateSystem, Position.of(start), Position.of(end));
+    }
+
+    private TestRegion(CoordinateSystem coordinateSystem, Position start, Position end) {
+        this.start = start;
+        this.end = end;
+        this.coordinateSystem = coordinateSystem;
+    }
+
+    @Override
+    public CoordinateSystem coordinateSystem() {
+        return coordinateSystem;
+    }
+
+    @Override
+    public Region withCoordinateSystem(CoordinateSystem coordinateSystem) {
+        return new TestRegion(coordinateSystem, normalisedStartPosition(coordinateSystem.startEndpoint()), normalisedEndPosition(coordinateSystem.endEndpoint()));
+    }
+
+    @Override
+    public Position startPosition() {
+        return start;
+    }
+
+    @Override
+    public Position endPosition() {
+        return end;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestRegion that = (TestRegion) o;
+        return Objects.equals(start, that.start) && Objects.equals(end, that.end) && coordinateSystem == that.coordinateSystem;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, end, coordinateSystem);
+    }
+
+    @Override
+    public String toString() {
+        return "TestRegion{" +
+                "start=" + start +
+                ", end=" + end +
+                ", coordinateSystem=" + coordinateSystem +
+                '}';
+    }
+}

--- a/src/test/java/org/monarchinitiative/variant/api/UnknownContigTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/UnknownContigTest.java
@@ -26,7 +26,7 @@ public class UnknownContigTest {
 
     @Test
     public void length() {
-        assertThat(unknown.length(), equalTo(1));
+        assertThat(unknown.length(), equalTo(0));
     }
 
     @Test

--- a/src/test/java/org/monarchinitiative/variant/api/impl/BreakendVariantTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/impl/BreakendVariantTest.java
@@ -26,8 +26,8 @@ public class BreakendVariantTest {
         // 13	123456	bnd_U	C	C[2:321682[	6	PASS	SVTYPE=BND;MATEID=bnd_V;EVENT=tra2
         Variant variant = breakendVariant_UV();
         assertThat(variant.contigId(), equalTo(13));
-        assertThat(variant.startPosition(), equalTo(Position.of(123_456)));
-        assertThat(variant.endPosition(), equalTo(Position.of(123_456)));
+        assertThat(variant.start(), equalTo(123_456));
+        assertThat(variant.end(), equalTo(123_456));
         assertThat(variant.strand(), equalTo(Strand.POSITIVE));
         assertThat(variant.variantType(), equalTo(VariantType.BND));
         assertThat(variant.coordinateSystem(), equalTo(CoordinateSystem.ZERO_BASED));
@@ -62,13 +62,13 @@ public class BreakendVariantTest {
 
         Breakend left = bnd_U.left();
         assertThat(left.contig(), equalTo(chr13));
-        assertThat(left.position(), equalTo(Position.of(123_456)));
+        assertThat(left.pos(), equalTo(123_456));
         assertThat(left.id(), equalTo("bnd_U"));
         assertThat(left.strand(), equalTo(Strand.POSITIVE));
 
         Breakend right = bnd_U.right();
         assertThat(right.contig(), equalTo(chr2));
-        assertThat(right.position(), equalTo(Position.of(321_681)));
+        assertThat(right.pos(), equalTo(321_682));
         assertThat(right.id(), equalTo("bnd_V"));
         assertThat(right.strand(), equalTo(Strand.POSITIVE));
     }
@@ -86,13 +86,13 @@ public class BreakendVariantTest {
 
         Breakend left = bnd_W.left();
         assertThat(left.contig(), equalTo(chr2));
-        assertThat(left.position(), equalTo(Position.of(321_681)));
+        assertThat(left.pos(), equalTo(321_681));
         assertThat(left.id(), equalTo("bnd_W"));
         assertThat(left.strand(), equalTo(Strand.POSITIVE));
 
         Breakend right = bnd_W.right();
         assertThat(right.contig(), equalTo(chr17));
-        assertThat(right.position(), equalTo(Position.of(chr17.length() - 198_981)));
+        assertThat(right.pos(), equalTo(chr17.length() - 198_981));
         assertThat(right.id(), equalTo("bnd_Y"));
         assertThat(right.strand(), equalTo(Strand.NEGATIVE));
     }
@@ -110,13 +110,13 @@ public class BreakendVariantTest {
 
         Breakend left = bnd_V.left();
         assertThat(left.contig(), equalTo(chr2));
-        assertThat(left.position(), equalTo(Position.of(chr2.length() - 321_681)));
+        assertThat(left.pos(), equalTo(chr2.length() - 321_681));
         assertThat(left.id(), equalTo("bnd_V"));
         assertThat(left.strand(), equalTo(Strand.NEGATIVE));
 
         Breakend right = bnd_V.right();
         assertThat(right.contig(), equalTo(chr13));
-        assertThat(right.position(), equalTo(Position.of(chr13.length() - 123_456)));
+        assertThat(right.pos(), equalTo(chr13.length() - 123_456 + 1));
         assertThat(right.id(), equalTo("bnd_U"));
         assertThat(right.strand(), equalTo(Strand.NEGATIVE));
     }
@@ -134,13 +134,13 @@ public class BreakendVariantTest {
 
         Breakend left = bnd_X.left();
         assertThat(left.contig(), equalTo(chr13));
-        assertThat(left.position(), equalTo(Position.of(chr13.length() - 123_456)));
+        assertThat(left.pos(), equalTo(chr13.length() - 123_456));
         assertThat(left.id(), equalTo("bnd_X"));
         assertThat(left.strand(), equalTo(Strand.NEGATIVE));
 
         Breakend right = bnd_X.right();
         assertThat(right.contig(), equalTo(chr17));
-        assertThat(right.position(), equalTo(Position.of(198_982)));
+        assertThat(right.pos(), equalTo(198_983));
         assertThat(right.id(), equalTo("bnd_Z"));
         assertThat(right.strand(), equalTo(Strand.POSITIVE));
     }
@@ -176,13 +176,13 @@ public class BreakendVariantTest {
 
         Breakend left = opposite.left();
         assertThat(left.contig(), equalTo(chr17));
-        assertThat(left.position(), equalTo(Position.of(chr17.length() - 198_982)));
+        assertThat(left.pos(), equalTo(chr17.length() - 198_982));
         assertThat(left.id(), equalTo("bnd_Z"));
         assertThat(left.strand(), equalTo(Strand.NEGATIVE));
 
         Breakend right = opposite.right();
         assertThat(right.contig(), equalTo(chr13));
-        assertThat(right.position(), equalTo(Position.of(123_456)));
+        assertThat(right.pos(), equalTo(123_457));
         assertThat(right.id(), equalTo("bnd_X"));
         assertThat(right.strand(), equalTo(Strand.POSITIVE));
 
@@ -228,7 +228,7 @@ public class BreakendVariantTest {
 
         Breakend r = instance.right();
         assertThat(r.contig(), equalTo(chr13));
-        assertThat(r.position(), equalTo(Position.of(123_456)));
+        assertThat(r.pos(), equalTo(123_457));
         assertThat(r.id(), equalTo("bnd_X"));
         assertThat(r.strand(), equalTo(Strand.POSITIVE));
 
@@ -238,7 +238,7 @@ public class BreakendVariantTest {
 
         Breakend oppositeLeft = variant.left();
         assertThat(oppositeLeft.contig(), equalTo(chr13));
-        assertThat(oppositeLeft.position(), equalTo(Position.of(chr13.length() - 123_456)));
+        assertThat(oppositeLeft.pos(), equalTo(chr13.length() - 123_456));
         assertThat(oppositeLeft.id(), equalTo("bnd_X"));
         assertThat(oppositeLeft.strand(), equalTo(Strand.NEGATIVE));
 
@@ -257,7 +257,7 @@ public class BreakendVariantTest {
 
         Breakend l = instance.left();
         assertThat(l.contig(), equalTo(chr2));
-        assertThat(l.position(), equalTo(Position.of(321_681)));
+        assertThat(l.pos(), equalTo(321_681));
         assertThat(l.id(), equalTo("bnd_W"));
         assertThat(l.strand(), equalTo(Strand.POSITIVE));
 
@@ -273,7 +273,7 @@ public class BreakendVariantTest {
 
         Breakend oppositeRight = variant.right();
         assertThat(oppositeRight.contig(), equalTo(chr2));
-        assertThat(oppositeRight.position(), equalTo(Position.of(chr2.length() - 321_681)));
+        assertThat(oppositeRight.pos(), equalTo(chr2.length() - 321_681 + 1));
         assertThat(oppositeRight.id(), equalTo("bnd_W"));
         assertThat(oppositeRight.strand(), equalTo(Strand.NEGATIVE));
     }
@@ -303,13 +303,13 @@ public class BreakendVariantTest {
 
         Breakend l = variant.left();
         assertThat(l.contig(), equalTo(chr2));
-        assertThat(l.position(), equalTo(Position.of(chr2.length() - 321_681)));
+        assertThat(l.pos(), equalTo(chr2.length() - 321_681));
         assertThat(l.id(), equalTo("bndV"));
         assertThat(l.strand(), equalTo(Strand.NEGATIVE));
 
         Breakend r = variant.right();
         assertThat(r.contig(), equalTo(chr13));
-        assertThat(r.position(), equalTo(Position.of(chr13.length() - 123_456)));
+        assertThat(r.pos(), equalTo(chr13.length() - 123_456));
         assertThat(r.id(), equalTo("bndU"));
         assertThat(r.strand(), equalTo(Strand.NEGATIVE));
     }
@@ -318,9 +318,9 @@ public class BreakendVariantTest {
     public void insertedSequence_NegNeg() {
         // #CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO
         // 2  321682  bndV  T  ]13:123456]AGTNNNNNCAT  6  PASS  SVTYPE=BND;MATEID=bndU
-        Breakend left = PartialBreakend.zeroBased(chr2, "bndV",Strand.POSITIVE, Position.of(321_682))
+        Breakend left = PartialBreakend.oneBased(chr2, "bndV",Strand.POSITIVE, Position.of(321_682))
                 .withStrand(Strand.NEGATIVE);
-        Breakend right = PartialBreakend.zeroBased(chr13, "bndU", Strand.POSITIVE, Position.of(123_456))
+        Breakend right = PartialBreakend.oneBased(chr13, "bndU", Strand.POSITIVE, Position.of(123_456))
                 .withStrand(Strand.NEGATIVE);
 
         // ref stays the same, while alt is reverse-complemented and stripped of bases shared with ref
@@ -341,13 +341,13 @@ public class BreakendVariantTest {
 
         Breakend l = variant.left();
         assertThat(l.contig(), equalTo(chr13));
-        assertThat(l.position(), equalTo(Position.of(123_456)));
+        assertThat(l.pos(), equalTo(123_456));
         assertThat(l.id(), equalTo("bndU"));
         assertThat(l.strand(), equalTo(Strand.POSITIVE));
 
         Breakend r = variant.right();
         assertThat(r.contig(), equalTo(chr2));
-        assertThat(r.position(), equalTo(Position.of(321_682)));
+        assertThat(r.pos(), equalTo(321_682));
         assertThat(r.id(), equalTo("bndV"));
         assertThat(r.strand(), equalTo(Strand.POSITIVE));
     }

--- a/src/test/java/org/monarchinitiative/variant/api/impl/DefaultContigTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/impl/DefaultContigTest.java
@@ -28,8 +28,8 @@ public class DefaultContigTest {
 
     @Test
     public void compareTo() {
-        assertThat(new TestContig(1, 1).compareTo(new TestContig(2, 2)), equalTo(-1));
-        assertThat(new TestContig(1, 1).compareTo(new TestContig(1, 1)), equalTo(0));
-        assertThat(new TestContig(2, 1).compareTo(new TestContig(1, 2)), equalTo(1));
+        assertThat(TestContig.of(1, 1).compareTo(TestContig.of(2, 2)), equalTo(-1));
+        assertThat(TestContig.of(1, 1).compareTo(TestContig.of(1, 1)), equalTo(0));
+        assertThat(TestContig.of(2, 1).compareTo(TestContig.of(1, 2)), equalTo(1));
     }
 }

--- a/src/test/java/org/monarchinitiative/variant/api/impl/DefaultGenomicRegionTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/impl/DefaultGenomicRegionTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class DefaultGenomicRegionTest {
 
-    Contig chr1 = new TestContig(1, 10);
+    Contig chr1 = TestContig.of(1, 10);
 
     @ParameterizedTest
     @CsvSource({
@@ -39,15 +39,16 @@ public class DefaultGenomicRegionTest {
         assertThat(instance.withStrand(exptStrand), equalTo(expected));
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "POSITIVE, ONE_BASED,  1, 1,  NEGATIVE, ONE_BASED,   1, 1",
-            "POSITIVE, ZERO_BASED, 0, 1,  NEGATIVE, ZERO_BASED,  0, 1",
-    })
-    public void emptyRegionUnknownChromosomeToOppositeStrand(Strand inputStrand, CoordinateSystem inputCoords, int inputStart, int inputEnd,
-                                                             Strand exptStrand, CoordinateSystem exptCoords, int exptStart, int exptEnd) {
-        GenomicRegion instance = DefaultGenomicRegion.of(Contig.unknown(), inputStrand, inputCoords, Position.of(inputStart), Position.of(inputEnd));
-        GenomicRegion expected = DefaultGenomicRegion.of(Contig.unknown(), exptStrand, exptCoords, Position.of(exptStart), Position.of(exptEnd));
-        assertThat(instance.withStrand(exptStrand), equalTo(expected));
-    }
+// TODO - figure out if this test is necessary since only empty region can be created on the "unknown" chromosome
+//    @ParameterizedTest
+//    @CsvSource({
+//            "POSITIVE, ONE_BASED,  1, 1,  NEGATIVE, ONE_BASED,   1, 1",
+//            "POSITIVE, ZERO_BASED, 0, 1,  NEGATIVE, ZERO_BASED,  0, 1",
+//    })
+//    public void emptyRegionUnknownChromosomeToOppositeStrand(Strand inputStrand, CoordinateSystem inputCoords, int inputStart, int inputEnd,
+//                                                             Strand exptStrand, CoordinateSystem exptCoords, int exptStart, int exptEnd) {
+//        GenomicRegion instance = DefaultGenomicRegion.of(Contig.unknown(), inputStrand, inputCoords, Position.of(inputStart, inputCoords.start()), Position.of(inputEnd, inputCoords.end()));
+//        GenomicRegion expected = DefaultGenomicRegion.of(Contig.unknown(), exptStrand, exptCoords, Position.of(exptStart, exptCoords.start()), Position.of(exptEnd, exptCoords.end()));
+//        assertThat(instance.withStrand(exptStrand), equalTo(expected));
+//    }
 }

--- a/src/test/java/org/monarchinitiative/variant/api/impl/DefaultVariantTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/impl/DefaultVariantTest.java
@@ -220,7 +220,7 @@ public class DefaultVariantTest {
 
     @Test
     public void delLenSvLen() {
-        Variant del = DefaultVariant.oneBased(chr1, "rs2376870", 2827694, "CGTGGATGCGGGGAC", "C");
+        Variant del = DefaultVariant.oneBased(TestContigs.chr1, "rs2376870", 2827694, "CGTGGATGCGGGGAC", "C");
         //.    PASS   SVTYPE=DEL;LEN=15;HOMLEN=1;HOMSEQ=G;SVLEN=-14
         assertThat(del.variantType(), equalTo(VariantType.DEL));
         assertThat(del.length(), equalTo(15));
@@ -337,7 +337,7 @@ public class DefaultVariantTest {
     @Test
     public void symbolicDelLenSvLen() {
         //1       321682 .         T                <DEL>        6    PASS   SVTYPE=DEL;LEN=206;SVLEN=-205;CIPOS=-56,20;CIEND=-10,62
-        Variant del = DefaultVariant.oneBased(chr1, 321682, 321682 + 205, "T", "<DEL>", -205);
+        Variant del = DefaultVariant.oneBased(TestContigs.chr1, 321682, 321682 + 205, "T", "<DEL>", -205);
         assertThat(del.length(), equalTo(206));
         assertThat(del.refLength(), equalTo(206));
         assertThat(del.changeLength(), equalTo(-205));

--- a/src/test/java/org/monarchinitiative/variant/api/impl/PartialBreakendTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/impl/PartialBreakendTest.java
@@ -15,28 +15,29 @@ public class PartialBreakendTest {
 
     @Test
     public void properties() {
-        PartialBreakend three = PartialBreakend.zeroBased(ctg1, "a", Strand.POSITIVE, Position.of(3, -2, 1));
+        PartialBreakend three = PartialBreakend.of(ctg1, "a", Strand.POSITIVE, Position.of(3, -2, 1));
 
         assertThat(three.contig(), equalTo(ctg1));
         assertThat(three.contigId(), equalTo(1));
         assertThat(three.contigName(), equalTo("1"));
-        assertThat(three.position(), equalTo(Position.of(3, ConfidenceInterval.of(-2, 1))));
         assertThat(three.pos(), equalTo(3));
-        assertThat(three.ci(), equalTo(ConfidenceInterval.of(-2, 1)));
-        assertThat(three.min(), equalTo(1));
-        assertThat(three.max(), equalTo(4));
+        assertThat(three.confidenceInterval(), equalTo(ConfidenceInterval.of(-2, 1)));
+        assertThat(three.minPos(), equalTo(1));
+        assertThat(three.maxPos(), equalTo(4));
         assertThat(three.strand(), equalTo(Strand.POSITIVE));
+        assertThat(three.id(), equalTo("a"));
     }
 
     @Test
     public void withStrand() {
-        PartialBreakend three = PartialBreakend.zeroBased(ctg1, "a", Strand.POSITIVE, Position.of(3, -2, 1));
+        PartialBreakend three = PartialBreakend.of(ctg1, "a", Strand.POSITIVE, Position.of(3, -2, 1));
 
         assertThat(three.withStrand(Strand.POSITIVE), is(sameInstance(three)));
 
         PartialBreakend breakend = three.withStrand(Strand.NEGATIVE);
         assertThat(breakend.contig(), equalTo(ctg1));
-        assertThat(breakend.position(), equalTo(Position.of(7, -1, 2)));
+        assertThat(breakend.pos(), equalTo(8));
+        assertThat(breakend.confidenceInterval(), equalTo(ConfidenceInterval.of(-1, 2)));
         assertThat(breakend.id(), is("a"));
     }
 

--- a/src/test/java/org/monarchinitiative/variant/api/impl/TestVariants.java
+++ b/src/test/java/org/monarchinitiative/variant/api/impl/TestVariants.java
@@ -23,7 +23,7 @@ public class TestVariants {
      * <pre>13	123456	bnd_U	C	C[2:321682[	6	PASS	SVTYPE=BND;MATEID=bnd_V;EVENT=tra2</pre>
      */
     public static BreakendVariant breakendVariant_UV() {
-        Breakend bnd_U = PartialBreakend.zeroBased(chr13, "bnd_U", Strand.POSITIVE, Position.of(123_456));
+        Breakend bnd_U = PartialBreakend.oneBased(chr13, "bnd_U", Strand.POSITIVE, Position.of(123_456));
         Breakend bnd_V = PartialBreakend.oneBased(chr2, "bnd_V", Strand.POSITIVE, Position.of(321_682));
         return new BreakendVariant("tra2", bnd_U, bnd_V, "C", "");
     }
@@ -37,7 +37,7 @@ public class TestVariants {
      */
     public static BreakendVariant breakendVariant_VU() {
         Breakend bnd_V = PartialBreakend.oneBased(chr2, "bnd_V", Strand.POSITIVE, Position.of(321_682)).withStrand(Strand.NEGATIVE);
-        Breakend bnd_U = PartialBreakend.zeroBased(chr13, "bnd_U", Strand.POSITIVE, Position.of(123_456)).withStrand(Strand.NEGATIVE);
+        Breakend bnd_U = PartialBreakend.oneBased(chr13, "bnd_U", Strand.POSITIVE, Position.of(123_456)).withStrand(Strand.NEGATIVE);
         return new BreakendVariant("tra2", bnd_V, bnd_U, "T", "");
     }
 
@@ -49,7 +49,7 @@ public class TestVariants {
      * <pre>2	321681	bnd_W	G	G]17:198982]	6	PASS	SVTYPE=BND;MATEID=bnd_Y;EVENT=tra1</pre>
      */
     public static BreakendVariant breakendVariant_WY() {
-        Breakend bnd_W = PartialBreakend.zeroBased(chr2, "bnd_W", Strand.POSITIVE, Position.of(321_681));
+        Breakend bnd_W = PartialBreakend.oneBased(chr2, "bnd_W", Strand.POSITIVE, Position.of(321_681));
         Breakend bnd_Y = PartialBreakend.oneBased(chr17, "bnd_Y", Strand.POSITIVE, Position.of(198_982)).withStrand(Strand.NEGATIVE);
         return new BreakendVariant("tra1", bnd_W, bnd_Y, "G", "");
     }
@@ -90,7 +90,7 @@ public class TestVariants {
      */
     public static BreakendVariant breakendVariant_VU_withInsertion() {
         Breakend bnd_V = PartialBreakend.oneBased(chr2, "bnd_V", Strand.POSITIVE, Position.of(321_682)).withStrand(Strand.NEGATIVE);
-        Breakend bnd_U = PartialBreakend.zeroBased(chr13, "bnd_U", Strand.POSITIVE, Position.of(123_456)).withStrand(Strand.NEGATIVE);
+        Breakend bnd_U = PartialBreakend.oneBased(chr13, "bnd_U", Strand.POSITIVE, Position.of(123_456)).withStrand(Strand.NEGATIVE);
         return new BreakendVariant("tra2", bnd_V, bnd_U, "T", "TGNNNNNACT");
     }
 
@@ -116,7 +116,7 @@ public class TestVariants {
      * See section 5.4.9 of VCF v4.2 specs for more info.
      */
     public static BreakendVariant bnd_W_rightUnresolved() {
-        Breakend left = PartialBreakend.zeroBased(chr2, "bnd_W", Strand.POSITIVE, Position.of(321_681));
+        Breakend left = PartialBreakend.oneBased(chr2, "bnd_W", Strand.POSITIVE, Position.of(321_681));
         Breakend right = Breakend.unresolved();
 
         return new BreakendVariant("", left, right, "G", "");


### PR DESCRIPTION
Hi @julesjacobsen this is the today's work. I think that I completed all things we discussed today (including my notes below).

In addition to the tasks we agreed upon, I added `BaseGenomicPosition`, which is extended by `PartialBreakend` and `DefaultGenomicPosition`.

The tests where we call `withStrand().withCoordinateSystem().withStrand().withCoordinateSystem()` and we check that we got the same thing still remain to be added...


---


- implement `Comparable` in `Region` subclasses
  - naturalOrder as in GenomicRegion

- behavior of coordinate system conversion of empty regions
  - 1-based empty region is possible if we allow end < start
  - let's allow this to not have to throw an exception

- update genomic position implementations
  - do we ever have an imprecise position that is not GenomicPosition as well? If not, then we can get rid of ImprecisePosition and create ImpreciseGenomicPosition
  - not really, we use composition and we're fine

- most of the methods like `contains` or `overlapsWith()` should be defined in `Region`. The extended versions that
  also check for contig and strand should be defined in `GenomicRegion`
  - let's make 2 versions, one for object the other is a pure function

- remove endpoint from position, add `CoordinateSystem` to `Region`
- contig should not be a region, use length to calculate the magic number for strand flipping
  - function probably on a region

- figure out the best place for getting the magic number for a contig that we need to flip strand of a region
- make sure we can flip strand of an empty region in any coordinate system
