### PR TITLE
Add BreakendParser and tests

### DIFF
--- a/src/main/java/org/monarchinitiative/variant/api/impl/Seq.java
+++ b/src/main/java/org/monarchinitiative/variant/api/impl/Seq.java
@@ -21,11 +21,6 @@ public class Seq {
 
     private static final Map<Byte, Byte> IUPAC_COMPLEMENT_MAP = makeIupacByteMap(IUPAC);
 
-    /**
-     *
-     */
-    static final String IUPAC_BASES = "ACGTUWSMKRYBDHVNacgtuwsmkrybdhvn";
-
     private Seq() {
         // static utility class
     }

--- a/src/main/java/org/monarchinitiative/variant/api/parsers/BreakendParser.java
+++ b/src/main/java/org/monarchinitiative/variant/api/parsers/BreakendParser.java
@@ -1,0 +1,107 @@
+package org.monarchinitiative.variant.api.parsers;
+
+import org.monarchinitiative.variant.api.*;
+import org.monarchinitiative.variant.api.impl.BreakendVariant;
+import org.monarchinitiative.variant.api.impl.PartialBreakend;
+import org.monarchinitiative.variant.api.impl.Seq;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class resolves a {@link BreakendVariant} from primitive inputs.
+ *
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ * @author Daniel Danis <daniel.danis@jax.org>
+ */
+public class BreakendParser {
+
+    private static final String IUPAC_BASES = "ACGTUWSMKRYBDHVNacgtuwsmkrybdhvn";
+
+    /**
+     * Any BND alt record must match this pattern (e.g. `G]1:123]`, `]1:123]G`, `G[1:123[`, `[1:123[G`).
+     *
+     * The pattern defines 6 groups: `head`, `left`, `contig`, `pos`, `right`, and `tail`, which capture the following
+     * content for alt record: `G]1:123]`:
+     * <ul>
+     *     <li>`head`   - a single ref base or  - </li>
+     *     <li>`left`   - the left bracket</li>
+     *     <li>`contig` - contig name of the mate breakend</li>
+     *     <li>`pos`    - position of the mate breakend</li>
+     *     <li>`right`  - the right bracket</li>
+     *     <li>`tail`   - any base sequence that is at the end of the alt record</li>
+     * </ul>
+     */
+    private static final Pattern BND_ALT_PATTERN = Pattern.compile(
+            String.format("^(?<head>[%s]*)(?<left>[\\[\\]])(?<contig>[\\w._<>]+):(?<pos>\\d+)(?<right>[\\[\\]])(?<tail>[%s]*)$",
+                    IUPAC_BASES, IUPAC_BASES));
+
+    private final GenomicAssembly genomicAssembly;
+
+    public BreakendParser(GenomicAssembly genomicAssembly) {
+        this.genomicAssembly = genomicAssembly;
+    }
+
+    public BreakendVariant resolve(String eventId, String id, String mateId, Contig contig, Position position, ConfidenceInterval ciEnd, String ref, String alt) {
+        Matcher altMatcher = BND_ALT_PATTERN.matcher(alt);
+        if (!altMatcher.matches())
+            throw new IllegalArgumentException("Invalid breakend alt record " + alt);
+
+        // parse mate data
+        String mateContigName = altMatcher.group("contig");
+        Contig mateContig = genomicAssembly.contigByName(mateContigName);
+        if (mateContig.equals(Contig.unknown()))
+            throw new IllegalArgumentException("Unknown mate contig `" + mateContigName + '`');
+
+        Position matePos = null;
+        try {
+            int pos = Integer.parseInt(altMatcher.group("pos"));
+            matePos = Position.of(pos, ciEnd);
+        } catch (NumberFormatException ignored) {
+            // swallow, this should not happen since we catch the situation where the `pos` group is not
+            // integer only upstream
+        }
+
+        // figure out strands and the inserted sequence
+        String head = altMatcher.group("head");
+        String tail = altMatcher.group("tail");
+        if (!head.isEmpty() && !tail.isEmpty())
+            throw new IllegalArgumentException("Sequence present both at the beginning (`" + head + "`) and the end (`" + tail + "`) of alt field");
+
+        // left breakend strand
+        Strand leftStrand;
+        char refBase = ref.charAt(0);
+        if (!head.isEmpty() && refBase == head.charAt(0))
+            leftStrand = Strand.POSITIVE;
+        else if (!tail.isEmpty() && refBase == tail.charAt(tail.length()-1))
+            leftStrand = Strand.NEGATIVE;
+        else
+            throw new IllegalArgumentException("Invalid breakend alt `" + alt + "`. No match for ref allele `"
+                    + ref + "` neither at the beginning nor at the end");
+
+        // right breakend strand
+        String leftBracket = altMatcher.group("left");
+        String rightBracket = altMatcher.group("right");
+        if (!leftBracket.equals(rightBracket))
+            throw new IllegalArgumentException("Invalid bracket orientation in `" + alt + '`');
+        Strand rightStrand = (leftBracket.equals("["))
+                ? Strand.POSITIVE
+                : Strand.NEGATIVE;
+
+        // inserted sequence - alt allele
+        String altSeq = leftStrand.isPositive()
+                ? head.substring(1)
+                : tail.substring(0, tail.length() - 1);
+
+
+        // assemble breakends and create the final BreakendVariant
+        Breakend left = PartialBreakend.oneBased(contig, id, Strand.POSITIVE, position).withStrand(leftStrand);
+        Breakend right = PartialBreakend.oneBased(mateContig, mateId, Strand.POSITIVE, matePos).withStrand(rightStrand);
+
+
+        return BreakendVariant.of(eventId, left, right,
+                leftStrand.isPositive() ? ref : Seq.reverseComplement(ref),
+                leftStrand.isPositive() ? altSeq : Seq.reverseComplement(altSeq));
+    }
+
+}

--- a/src/test/java/org/monarchinitiative/variant/api/parsers/BreakendParserTest.java
+++ b/src/test/java/org/monarchinitiative/variant/api/parsers/BreakendParserTest.java
@@ -1,0 +1,136 @@
+package org.monarchinitiative.variant.api.parsers;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.monarchinitiative.variant.api.*;
+import org.monarchinitiative.variant.api.impl.BreakendVariant;
+import org.monarchinitiative.variant.api.impl.DefaultGenomicAssembly;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.Matchers.*;
+import static org.monarchinitiative.variant.api.AssignedMoleculeType.CHROMOSOME;
+import static org.monarchinitiative.variant.api.SequenceRole.ASSEMBLED_MOLECULE;
+
+/**
+ * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
+ * @author Daniel Danis <daniel.danis@jax.org>
+ */
+public class BreakendParserTest {
+
+    public static final Contig chr1 = Contig.of(1, "1", ASSEMBLED_MOLECULE, "1", CHROMOSOME, 249250621, "NC_000001.10", "CM000663.1", "chr1");
+    public static final Contig chr2 = Contig.of(2, "2", ASSEMBLED_MOLECULE, "2", CHROMOSOME, 243_199_373, "CM000664.1", "NC_000002.11", "chr2");
+    public static final Contig chr13 = Contig.of(3, "13", ASSEMBLED_MOLECULE, "13", CHROMOSOME, 115_169_878, "CM000675.1", "NC_000013.10", "chr13");
+    public static final Contig chr17 = Contig.of(4, "17", ASSEMBLED_MOLECULE, "17", CHROMOSOME, 83_257_441, "CM000679.2", "NC_000017.11", "chr17");
+
+    private static GenomicAssembly ASSEMBLY;
+
+    private BreakendParser parser;
+
+    @BeforeAll
+    public static void beforeAll() {
+        List<Contig> contigs = List.of(chr1, chr2, chr13, chr17);
+        ASSEMBLY = DefaultGenomicAssembly.builder().name("TestAssembly").name("test").organismName("Wookie")
+                .taxId("9607").date("3021-01-15").submitter("Han").genBankAccession("GB1").refSeqAccession("RS1")
+                .contigs(contigs)
+                .build();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        parser = new BreakendParser(ASSEMBLY);
+    }
+
+    @Test
+    public void resolve_PosPos() {
+        // 13	123456	bnd_U	C	C[2:321682[	6	PASS	SVTYPE=BND;MATEID=bnd_V;EVENT=tra2
+        BreakendVariant variant = parser.resolve("tra2", "bnd_U", "bnd_V", chr13,
+                Position.of(123_456), ConfidenceInterval.precise(), "C", "C[2:321682[");
+
+        // Breakended bits
+        assertThat(variant.mateId(), equalTo("bnd_V"));
+        assertThat(variant.eventId(), equalTo("tra2"));
+
+        // Variant bits
+        assertThat(variant.id(), equalTo("bnd_U"));
+        assertThat(variant.ref(), equalTo("C"));
+        assertThat(variant.alt(), equalTo("")); // no inserted sequence
+        assertThat(variant.refLength(), equalTo(1));
+        assertThat(variant.changeLength(), equalTo(0)); // length of the inserted sequence
+        assertThat(variant.length(), equalTo(0)); // length of the inserted sequence
+        assertThat(variant.variantType(), equalTo(VariantType.BND));
+        assertThat(variant.isSymbolic(), equalTo(true));
+
+        // Left breakend
+        Breakend left = variant.left();
+        assertThat(left.id(), equalTo("bnd_U"));
+        assertThat(left.isUnresolved(), equalTo(false));
+        assertThat(left.contig(), equalTo(chr13));
+        assertThat(left.startPosition(), equalTo(Position.of(123_456)));
+        assertThat(left.endPosition(), equalTo(Position.of(123_456)));
+        assertThat(left.strand(), equalTo(Strand.POSITIVE));
+        assertThat(left.coordinateSystem(), equalTo(CoordinateSystem.oneBased()));
+
+        // Right breakend
+        Breakend right = variant.right();
+        assertThat(right.id(), equalTo("bnd_V"));
+        assertThat(right.isUnresolved(), equalTo(false));
+        assertThat(right.contig(), equalTo(chr2));
+        assertThat(right.startPosition(), equalTo(Position.of(321_682)));
+        assertThat(right.endPosition(), equalTo(Position.of(321_682)));
+        assertThat(right.strand(), equalTo(Strand.POSITIVE));
+        assertThat(right.coordinateSystem(), equalTo(CoordinateSystem.oneBased()));
+    }
+
+    @Test
+    public void resolve_NegPos() {
+        // 13  123457  bnd_X   A   [17:198983[A    6   PASS    SVTYPE=BND;MATEID=bnd_Z;EVENT=tra3
+        BreakendVariant variant = parser.resolve("tra3", "bnd_X", "bnd_Z", chr13,
+                Position.of(123_457), ConfidenceInterval.precise(), "A", "[17:198983[A");
+
+        assertThat(variant.left().contig(), equalTo(chr13));
+        assertThat(variant.left().startPosition(), equalTo(Position.of(chr13.length() - 123_457 + 1)));
+        assertThat(variant.left().strand(), equalTo(Strand.NEGATIVE));
+
+        assertThat(variant.right().contig(), equalTo(chr17));
+        assertThat(variant.right().startPosition(), equalTo(Position.of(198_983)));
+        assertThat(variant.right().strand(), equalTo(Strand.POSITIVE));
+    }
+
+    @Test
+    public void resolve_PosNeg() {
+        // 2	321681	bnd_W	G	G]17:198982]	6	PASS	SVTYPE=BND;MATEID=bnd_Y;EVENT=tra1
+        BreakendVariant variant = parser.resolve("tra1", "bnd_W", "bnd_Y", chr2,
+                Position.of(321_681), ConfidenceInterval.precise(), "G", "G]17:198982]");
+
+        assertThat(variant.left().contig(), equalTo(chr2));
+        assertThat(variant.left().startPosition(), equalTo(Position.of(321_681)));
+        assertThat(variant.left().strand(), equalTo(Strand.POSITIVE));
+
+        assertThat(variant.right().contig(), equalTo(chr17));
+        assertThat(variant.right().startPosition(), equalTo(Position.of(chr17.length() - 198_982 + 1)));
+        assertThat(variant.right().strand(), equalTo(Strand.NEGATIVE));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "C,  C(2:321682[,      Invalid breakend alt record C(2:321682[",
+            "C,  C[2:32I682[,      Invalid breakend alt record C[2:32I682[",
+            "C,  C[X:321682[,      Unknown mate contig `X`",
+            "C,  C[2:321682[G,     Sequence present both at the beginning (`C`) and the end (`G`) of alt field",
+            "C,  G[2:321682[,      Invalid breakend alt `G[2:321682[`. No match for ref allele `C` neither at the beginning nor at the end",
+            "C,  [2:321682[G,      Invalid breakend alt `[2:321682[G`. No match for ref allele `C` neither at the beginning nor at the end",
+            "C,  C[2:321682],      Invalid bracket orientation in `C[2:321682]`",
+    })
+    public void resolve_invalidInput(String ref, String alt, String message) {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> parser.resolve("tra2", "bnd_U", "bnd_V", chr13,
+                Position.of(123_456), ConfidenceInterval.precise(), ref, alt));
+        assertThat(e.getMessage(), equalTo(message));
+    }
+}


### PR DESCRIPTION
Adding `BreakendParser` and extensive tests that exercise all possible breakend orientations as well as almost all lines of code.