### PR TITLE
Fix GenomicAssembly static constructor

### DIFF
--- a/src/main/java/org/monarchinitiative/svart/GenomicAssembly.java
+++ b/src/main/java/org/monarchinitiative/svart/GenomicAssembly.java
@@ -73,7 +73,7 @@ public interface GenomicAssembly {
 //# RefSeq assembly accession: GCF_000001405.39
 //# RefSeq assembly and GenBank assemblies identical: no
 
-    default GenomicAssembly of(String name, String organismName, String taxId, String submitter, String date, String genBankAccession, String refSeqAccession, Collection<Contig> contigs) {
+    static GenomicAssembly of(String name, String organismName, String taxId, String submitter, String date, String genBankAccession, String refSeqAccession, Collection<Contig> contigs) {
         return DefaultGenomicAssembly.builder()
                 .name(name)
                 .organismName(organismName)

--- a/src/test/java/org/monarchinitiative/svart/GenomicAssemblyTest.java
+++ b/src/test/java/org/monarchinitiative/svart/GenomicAssemblyTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class GenomicAssemblyTest {
 
@@ -22,5 +24,27 @@ public class GenomicAssemblyTest {
         assertThat(GenomicAssembly.readAssembly(Files.newInputStream(assemblyPath)).name(), equalTo("GRCh37.p13"));
     }
 
+    @Test
+    public void fromScratch() {
+        List<Contig> contigs = List.of(
+                Contig.of(1, "1", SequenceRole.ASSEMBLED_MOLECULE, "1", AssignedMoleculeType.CHROMOSOME, 248_956_422, "CM000663.2", "NC_000001.11", "chr1"),
+                Contig.of(2, "2", SequenceRole.ASSEMBLED_MOLECULE, "2", AssignedMoleculeType.CHROMOSOME, 248_956_422, "CM000664.2", "NC_000002.12", "chr2")
+        );
+        GenomicAssembly assembly = GenomicAssembly.of("GRCh38.p13", "Homo sapiens (human)", "9606",
+                "Genome Reference Consortium", "2019-02-28",
+                "GCA_000001405.28", "GCF_000001405.39",
+                contigs);
 
+        assertThat(assembly.name(), equalTo("GRCh38.p13"));
+        assertThat(assembly.organismName(), equalTo("Homo sapiens (human)"));
+        assertThat(assembly.taxId(), equalTo("9606"));
+        assertThat(assembly.submitter(), equalTo("Genome Reference Consortium"));
+        assertThat(assembly.date(), equalTo("2019-02-28"));
+        assertThat(assembly.genBankAccession(), equalTo("GCA_000001405.28"));
+        assertThat(assembly.refSeqAccession(), equalTo("GCF_000001405.39"));
+
+        assertThat(assembly.contigs(), hasSize(2));
+        assertThat(assembly.contigByName("1"), equalTo(contigs.get(0)));
+        assertThat(assembly.contigByName("2"), equalTo(contigs.get(1)));
+    }
 }


### PR DESCRIPTION
Hi @julesjacobsen I think I found a bug. We should be able to use the `GenomicAssembly.of(...)` to create an instance. Therefore, the constructor needs to be `static` and not `default`.

I am including the fix and a test. Please merge if it's OK.