### PR TITLE
Implement `distanceTo` for regions

### DIFF
--- a/src/main/java/org/monarchinitiative/svart/Coordinates.java
+++ b/src/main/java/org/monarchinitiative/svart/Coordinates.java
@@ -95,6 +95,29 @@ public class Coordinates {
         return openStart(aSystem, aStart) <= openStart(bSystem, bStart) && closedEnd(bSystem, bEnd) <= closedEnd(aSystem, aEnd);
     }
 
+    /**
+     * Returns the number of bases present between the intervals <code>a</code> and <code>b</code>. The distance is zero
+     * if the <code>a</code> and <code>b</code> are adjacent or if they overlap. The distance is positive if <code>a</code>
+     * is downstream of <code>b</code> and negative if <code>a</code> is located downstream from <code>b</code>.
+     *
+     * @param aSystem {@link CoordinateSystem} for interval described by positions aStart and aEnd
+     * @param aStart  start coordinate of interval a
+     * @param aEnd    end coordinate of interval a
+     * @param bSystem {@link CoordinateSystem} for interval described by positions bStart and bEnd
+     * @param bStart  start coordinate of interval b
+     * @param bEnd    end coordinate of interval b
+     * @return distance from interval <code>a</code> to interval <code>b</code>
+     */
+    public static int distanceTo(CoordinateSystem aSystem, int aStart, int aEnd, CoordinateSystem bSystem, int bStart, int bEnd) {
+        if (overlap(aSystem, aStart, aEnd, bSystem, bStart, bEnd)) return 0;
+
+        int first = openStart(bSystem, bStart) - closedEnd(aSystem, aEnd) ;
+        int second = openStart(aSystem, aStart) - closedEnd(bSystem, bEnd);
+
+        int result = Math.abs(first) < Math.abs(second) ? first : second;
+        return first > second ? result : -result;
+    }
+
     private static boolean isEmpty(CoordinateSystem coordinateSystem, int start, int end) {
         return length(coordinateSystem, start, end) == 0;
     }

--- a/src/main/java/org/monarchinitiative/svart/GenomicRegion.java
+++ b/src/main/java/org/monarchinitiative/svart/GenomicRegion.java
@@ -84,6 +84,29 @@ public interface GenomicRegion extends Region<GenomicRegion>, Stranded<GenomicRe
         return Coordinates.aContainsB(coordinateSystem(), start(), end(), other.coordinateSystem(), otherStart, otherEnd);
     }
 
+    /**
+     * Returns the distance between <code>this</code> and the <code>other</code> regions. The distance represents
+     * the number of bases present between the regions.
+     * <p>
+     * The distance is zero if the <code>a</code> and <code>b</code>
+     * are adjacent or if they overlap. The distance is positive if <code>a</code> is downstream of <code>b</code>
+     * and negative if <code>a</code> is located downstream from <code>b</code>.
+     *
+     * @param other genomic region
+     * @return distance from <code>this</code> region to the <code>other</code> region
+     */
+    default int distanceTo(GenomicRegion other) {
+        if (contig().id() != other.contig().id()) {
+            throw new IllegalArgumentException("Cannot calculate distance between regions on different contigs: " + contig().id() + " <-> " + other.contig().id());
+        }
+        if (this.strand() == other.strand()) {
+            return Coordinates.distanceTo(coordinateSystem(), start(), end(), other.coordinateSystem(), other.start(), other.end());
+        }
+        int otherStart = other.startOnStrand(this.strand());
+        int otherEnd = other.endOnStrand(this.strand());
+        return Coordinates.distanceTo(coordinateSystem(), start(), end(), other.coordinateSystem(), otherStart, otherEnd);
+    }
+
     default GenomicRegion withPadding(int padding) {
         return withPadding(padding, padding);
     }

--- a/src/main/java/org/monarchinitiative/svart/Region.java
+++ b/src/main/java/org/monarchinitiative/svart/Region.java
@@ -67,6 +67,21 @@ public interface Region<T> extends CoordinateSystemed<T> {
         return Coordinates.overlap(coordinateSystem(), start(), end(), other.coordinateSystem(), other.start(), other.end());
     }
 
+    /**
+     * Returns the distance between <code>this</code> and the <code>other</code> regions. The distance represents
+     * the number of bases present between the regions.
+     * <p>
+     * The distance is zero if the <code>a</code> and <code>b</code>
+     * are adjacent or if they overlap. The distance is positive if <code>a</code> is downstream of <code>b</code>
+     * and negative if <code>a</code> is located downstream from <code>b</code>.
+     *
+     * @param other region
+     * @return distance from <code>this</code> region to the <code>other</code> region
+     */
+    default int distanceTo(Region<?> other) {
+        return Coordinates.distanceTo(coordinateSystem(), start(), end(), other.coordinateSystem(), other.start(), other.end());
+    }
+
     default int length() {
         return Coordinates.length(coordinateSystem(), start(), end());
     }

--- a/src/test/java/org/monarchinitiative/svart/CoordinatesTest.java
+++ b/src/test/java/org/monarchinitiative/svart/CoordinatesTest.java
@@ -248,4 +248,93 @@ public class CoordinatesTest {
         }
 
     }
+
+    @Nested
+    public class DistanceTo {
+
+        @ParameterizedTest
+        @CsvSource({
+                // overlapping regions, thus distance is 0
+                "FULLY_CLOSED, 1, 2,   FULLY_CLOSED,  2, 3,    0",
+                "FULLY_CLOSED, 1, 2,   LEFT_OPEN,     1, 3,    0",
+                "FULLY_CLOSED, 1, 2,   RIGHT_OPEN,    2, 4,    0",
+                "FULLY_CLOSED, 1, 2,   FULLY_OPEN,    1, 4,    0",
+
+                "LEFT_OPEN,    0, 2,   FULLY_CLOSED,  2, 3,    0",
+                "LEFT_OPEN,    0, 2,   LEFT_OPEN,     1, 3,    0",
+                "LEFT_OPEN,    0, 2,   RIGHT_OPEN,    2, 4,    0",
+                "LEFT_OPEN,    0, 2,   FULLY_OPEN,    1, 4,    0",
+
+                "RIGHT_OPEN,   1, 3,   FULLY_CLOSED,  2, 3,    0",
+                "RIGHT_OPEN,   1, 3,   LEFT_OPEN,     1, 3,    0",
+                "RIGHT_OPEN,   1, 3,   RIGHT_OPEN,    2, 4,    0",
+                "RIGHT_OPEN,   1, 3,   FULLY_OPEN,    1, 4,    0",
+
+                "FULLY_OPEN,   0, 3,   FULLY_CLOSED,  2, 3,    0",
+                "FULLY_OPEN,   0, 3,   LEFT_OPEN,     1, 3,    0",
+                "FULLY_OPEN,   0, 3,   RIGHT_OPEN,    2, 4,    0",
+                "FULLY_OPEN,   0, 3,   FULLY_OPEN,    1, 4,    0",
+        })
+        public void overlapping(CoordinateSystem x, int xStart, int xEnd, CoordinateSystem y, int yStart, int yEnd, int expected) {
+            assertThat(Coordinates.distanceTo(x, xStart, xEnd, y, yStart, yEnd), is(expected));
+            assertThat(Coordinates.distanceTo(y, yStart, yEnd, x, xStart, xEnd), is(-expected));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                // adjacent, thus distance is 0
+                "FULLY_CLOSED, 1, 2,   FULLY_CLOSED,    3, 4,    0",
+                "FULLY_CLOSED, 1, 2,   LEFT_OPEN,       2, 4,    0",
+                "FULLY_CLOSED, 1, 2,   RIGHT_OPEN,      3, 5,    0",
+                "FULLY_CLOSED, 1, 2,   FULLY_OPEN,      2, 5,    0",
+
+                "LEFT_OPEN,    0, 2,   FULLY_CLOSED,    3, 4,    0",
+                "LEFT_OPEN,    0, 2,   LEFT_OPEN,       2, 4,    0",
+                "LEFT_OPEN,    0, 2,   RIGHT_OPEN,      3, 5,    0",
+                "LEFT_OPEN,    0, 2,   FULLY_OPEN,      2, 5,    0",
+
+                "RIGHT_OPEN,   1, 3,   FULLY_CLOSED,    3, 4,    0",
+                "RIGHT_OPEN,   1, 3,   LEFT_OPEN,       2, 4,    0",
+                "RIGHT_OPEN,   1, 3,   RIGHT_OPEN,      3, 5,    0",
+                "RIGHT_OPEN,   1, 3,   FULLY_OPEN,      2, 5,    0",
+
+                "FULLY_OPEN,   0, 3,   FULLY_CLOSED,    3, 4,    0",
+                "FULLY_OPEN,   0, 3,   LEFT_OPEN,       2, 4,    0",
+                "FULLY_OPEN,   0, 3,   RIGHT_OPEN,      3, 5,    0",
+                "FULLY_OPEN,   0, 3,   FULLY_OPEN,      2, 5,    0",
+        })
+        public void adjacent(CoordinateSystem x, int xStart, int xEnd, CoordinateSystem y, int yStart, int yEnd, int expected) {
+            assertThat(Coordinates.distanceTo(x, xStart, xEnd, y, yStart, yEnd), is(expected));
+            assertThat(Coordinates.distanceTo(y, yStart, yEnd, x, xStart, xEnd), is(-expected));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                // all possible combinations of coordinate systems
+                "FULLY_CLOSED, 1, 2,   FULLY_CLOSED,    5, 6,    2",
+                "FULLY_CLOSED, 1, 2,   LEFT_OPEN,       4, 6,    2",
+                "FULLY_CLOSED, 1, 2,   RIGHT_OPEN,      5, 7,    2",
+                "FULLY_CLOSED, 1, 2,   FULLY_OPEN,      4, 7,    2",
+
+                "LEFT_OPEN,    0, 2,   FULLY_CLOSED,    5, 6,    2",
+                "LEFT_OPEN,    0, 2,   LEFT_OPEN,       4, 6,    2",
+                "LEFT_OPEN,    0, 2,   RIGHT_OPEN,      5, 7,    2",
+                "LEFT_OPEN,    0, 2,   FULLY_OPEN,      4, 7,    2",
+
+                "RIGHT_OPEN,   1, 3,   FULLY_CLOSED,    5, 6,    2",
+                "RIGHT_OPEN,   1, 3,   LEFT_OPEN,       4, 6,    2",
+                "RIGHT_OPEN,   1, 3,   RIGHT_OPEN,      5, 7,    2",
+                "RIGHT_OPEN,   1, 3,   FULLY_OPEN,      4, 7,    2",
+
+                "FULLY_OPEN,   0, 3,   FULLY_CLOSED,    5, 6,    2",
+                "FULLY_OPEN,   0, 3,   LEFT_OPEN,       4, 6,    2",
+                "FULLY_OPEN,   0, 3,   RIGHT_OPEN,      5, 7,    2",
+                "FULLY_OPEN,   0, 3,   FULLY_OPEN,      4, 7,    2",
+        })
+        public void distanceIsTwo(CoordinateSystem x, int xStart, int xEnd, CoordinateSystem y, int yStart, int yEnd, int expected) {
+            assertThat(Coordinates.distanceTo(x, xStart, xEnd, y, yStart, yEnd), is(expected));
+            assertThat(Coordinates.distanceTo(y, yStart, yEnd, x, xStart, xEnd), is(-expected));
+        }
+    }
+
 }

--- a/src/test/java/org/monarchinitiative/svart/GenomicRegionTest.java
+++ b/src/test/java/org/monarchinitiative/svart/GenomicRegionTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
@@ -222,6 +223,39 @@ public class GenomicRegionTest {
         Contig ctg2 = TestContig.of(2, 200);
         GenomicRegion other = GenomicRegion.oneBased(ctg2, Strand.POSITIVE, Position.of(2), Position.of(3));
         assertThat(oneToThree.contains(other), equalTo(false));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "POSITIVE, 4, 5,   POSITIVE, 1,  2,  -1",
+            "POSITIVE, 4, 5,   NEGATIVE, 9, 10,  -1",
+            "POSITIVE, 4, 5,   POSITIVE, 2,  3,   0",
+            "POSITIVE, 4, 5,   NEGATIVE, 8,  9,   0",
+            "POSITIVE, 4, 5,   POSITIVE, 3,  4,   0",
+            "POSITIVE, 4, 5,   NEGATIVE, 7,  8,   0",
+            "POSITIVE, 4, 5,   POSITIVE, 6,  7,   0",
+            "POSITIVE, 4, 5,   NEGATIVE, 4,  5,   0",
+            "POSITIVE, 4, 5,   POSITIVE, 7,  8,   1",
+            "POSITIVE, 4, 5,   NEGATIVE, 3,  4,   1",
+    })
+    public void distanceTo(Strand xStrand, int xStart, int xEnd,
+                           Strand yStrand, int yStart, int yEnd,
+                           int expected) {
+        Contig ctg1 = TestContig.of(1, 10);
+        GenomicRegion x = GenomicRegion.of(ctg1, xStrand, CoordinateSystem.oneBased(), Position.of(xStart), Position.of(xEnd));
+        GenomicRegion y = GenomicRegion.of(ctg1, yStrand, CoordinateSystem.oneBased(), Position.of(yStart), Position.of(yEnd));
+        assertThat(x.distanceTo(y), equalTo(expected));
+    }
+
+    @Test
+    public void distanceTo_otherContig() {
+        GenomicRegion x = GenomicRegion.of(TestContig.of(1, 10), Strand.POSITIVE, CoordinateSystem.oneBased(), Position.of(1), Position.of(2));
+        GenomicRegion y = GenomicRegion.of(TestContig.of(2, 10), Strand.POSITIVE, CoordinateSystem.oneBased(), Position.of(1), Position.of(2));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> x.distanceTo(y));
+        assertThat(e.getMessage(), equalTo("Cannot calculate distance between regions on different contigs: 1 <-> 2"));
+
+        IllegalArgumentException f = assertThrows(IllegalArgumentException.class, () -> y.distanceTo(x));
+        assertThat(f.getMessage(), equalTo("Cannot calculate distance between regions on different contigs: 2 <-> 1"));
     }
 
     @Test

--- a/src/test/java/org/monarchinitiative/svart/RegionTest.java
+++ b/src/test/java/org/monarchinitiative/svart/RegionTest.java
@@ -79,6 +79,26 @@ public class RegionTest {
         assertThat(region.overlapsWith(query), equalTo(expected));
     }
 
+
+    @ParameterizedTest
+    @CsvSource({
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 1, 2,  -1",
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 2, 3,  0",
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 3, 4,  0",
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 4, 5,  0",
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 5, 6,  0",
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 6, 7,  0",
+            "FULLY_CLOSED, 4, 5,   FULLY_CLOSED, 7, 8,  1",
+    })
+    public void distanceTo(CoordinateSystem coordinateSystem, int start, int end,
+                           CoordinateSystem queryCoordinateSystem, int queryStart, int queryEnd,
+                           int expected) {
+        TestRegion region = TestRegion.of(coordinateSystem, start, end);
+        TestRegion query = TestRegion.of(queryCoordinateSystem, queryStart, queryEnd);
+
+        assertThat(region.distanceTo(query), equalTo(expected));
+    }
+
     @ParameterizedTest
     @CsvSource({
             "FULLY_OPEN,   1, 2,   0",


### PR DESCRIPTION
@julesjacobsen I want to propose a function for `GenomicRegion` and `Region` to calculate a distance to another region. The distance represents number of positions (bases) that are between the regions. Therefore, the distance is `0` for adjacent of overlapping regions.

The distance is _signed_. For regions `a` and `b`, the distance is positive if `b` is downstream of `a` and the distance is negative if `b` is upstream of `a`. In fact, the distance might be `0` and `-0` for the adjacent regions.

Thanks to your primitive methods for strands and coordinate systems, the implementation only works with primitives (hopefully) without increasing GC pressure.

I think it might be beneficial to have this distance available. Thanks to this method, implementing methods such as `isUpstreamOf(GenomicRegion region)`, which is currently in Jannovar, should be a piece of cake.

What do you think?