### PR TITLE
MNV parse issue

### DIFF
--- a/src/test/java/org/monarchinitiative/svart/VariantTypeTest.java
+++ b/src/test/java/org/monarchinitiative/svart/VariantTypeTest.java
@@ -32,6 +32,8 @@ public class VariantTypeTest {
     @CsvSource({
             "A, T,    SNV",
             "ATG, TCA,    MNV",
+            "ATG, TC,    MNV",
+            "AT, TCA,    MNV",
             "TC, A,    DEL",
             "A, TC,    INS",
             "N, <DEL>,    DEL",


### PR DESCRIPTION
Hi @julesjacobsen 

this is the issue I mentioned with MNVs. MNVs having alleles of different length are not recognized as MNV, but as INS or DEL. This makes the test cases 3 and 4 in the snippet below (excerpt from `VariantTypeTest`) to fail. Also, I think the test cases 5, 6 are incorrect, as these are in fact MNVs and not DEL/INS.

```java
@ParameterizedTest
    @CsvSource({
            "A, T,    SNV",
            "ATG, TCA,    MNV",
            "ATG, TC,    MNV",
            "AT, TCA,    MNV",
            "TC, A,    DEL",
            "A, TC,    INS",
            "N, <DEL>,    DEL",
            "N, <INS>,    INS",
            "N, <INS:ME>,    INS_ME",
            "'', <INS:ME>,    INS_ME",
            "N, <INS:ME:ALU>,    INS_ME_ALU",
            "N, <CNV:GAIN>,    CNV_GAIN",
            "N, C[2:12345[,    BND",
    })
    public void parseTypeRefAlt(String ref, String alt, VariantType baseType) {
        assertThat(VariantType.parseType(ref, alt), equalTo(baseType));
    }
```

I'll be working on a fix and I'll add the code here.