### PR TITLE
`BreakendVariant.mateId()` returns `id()` of the right breakend.

### DIFF
--- a/src/main/java/org/monarchinitiative/svart/BreakendVariant.java
+++ b/src/main/java/org/monarchinitiative/svart/BreakendVariant.java
@@ -10,7 +10,7 @@ public interface BreakendVariant extends Variant {
     String eventId();
 
     default String mateId() {
-        return right().mateId();
+        return right().id();
     }
 
     Breakend left();


### PR DESCRIPTION
Address #53 