### PR TITLE
Fix for issue #72 - Telomeric variants throwing CoordinatesOutOfBoundsException.

### DIFF
--- a/src/main/java/org/monarchinitiative/svart/GenomicBreakend.java
+++ b/src/main/java/org/monarchinitiative/svart/GenomicBreakend.java
@@ -11,7 +11,11 @@ import org.monarchinitiative.svart.variant.DefaultGenomicBreakend;
 public interface GenomicBreakend extends GenomicRegion {
 
     static GenomicBreakend unresolved(CoordinateSystem coordinateSystem) {
-        return UnresolvedGenomicBreakend.instance(coordinateSystem);
+        return UnresolvedGenomicBreakend.of(coordinateSystem);
+    }
+
+    static GenomicBreakend unresolved(CoordinateSystem coordinateSystem, String id) {
+        return UnresolvedGenomicBreakend.of(coordinateSystem, id);
     }
 
     /**
@@ -42,7 +46,7 @@ public interface GenomicBreakend extends GenomicRegion {
      * @return <code>true</code> if the breakend is unresolved
      */
     default boolean isUnresolved() {
-        return this.equals(unresolved(coordinateSystem()));
+        return false;
     }
 
     static GenomicBreakend of(Contig contig, String id, Strand strand, CoordinateSystem coordinateSystem, int start, int end) {

--- a/src/main/java/org/monarchinitiative/svart/UnresolvedGenomicBreakend.java
+++ b/src/main/java/org/monarchinitiative/svart/UnresolvedGenomicBreakend.java
@@ -1,56 +1,114 @@
 package org.monarchinitiative.svart;
 
+import java.util.Objects;
+
 /**
+ * Represents an unresolved genomic breakend that serves as a placeholder when the mate breakend
+ * location cannot be determined or is not specified.
+ *
+ * <p>An unresolved breakend is typically used in scenarios where:
+ * <ul>
+ *   <li>A breakend variant has no mate partner (e.g., telomeric breakends)</li>
+ *   <li>The mate breakend is located on an unknown or unmapped contig</li>
+ *   <li>Parsing errors occur that prevent mate breakend resolution</li>
+ *   <li>Single breakend records are processed independently</li>
+ *   <li>Non-canonical breakend representations like Manta's unresolved breakends (e.g., {@code C.} or {@code .C})</li>
+ * </ul>
+ *
+ * <p>This class extends {@link BaseGenomicRegion} and implements {@link GenomicBreakend},
+ * providing a concrete implementation for breakends that cannot be resolved to a specific
+ * genomic location. All unresolved breakends are located on an {@link Contig#unknown()}
+ * contig and positioned on the {@link Strand#POSITIVE} strand by default.
+ *
+ * <p>The class maintains immutability and provides factory methods for creation with
+ * different levels of information available. It supports coordinate system conversions
+ * while preserving the unresolved state and maintains optional mate and event identifiers
+ * for tracking relationships between breakend pairs, if known.
+
+ * <h3>Usage Examples:</h3>
+ * <pre>{@code
+ * // Create a basic unresolved breakend
+ * GenomicBreakend breakend = UnresolvedGenomicBreakend.of(CoordinateSystem.ONE_BASED);
+ *
+ * // Create with identifiers for mate tracking
+ * GenomicBreakend breakend = UnresolvedGenomicBreakend.of(CoordinateSystem.ONE_BASED, "bnd_A", "bnd_B", "event1");
+ *
+ * // Access via GenomicBreakend interface
+ * GenomicBreakend unresolved = GenomicBreakend.unresolved(CoordinateSystem.ZERO_BASED);
+ * assert unresolved.isUnresolved() == true;
+ * }</pre>
+ *
+ * <h3>VCF Integration:</h3>
+ * <p>This class is used by {@link org.monarchinitiative.svart.vcf.VcfBreakendResolver} when processing
+ * VCF breakend records that cannot be resolved to specific genomic coordinates, and by
+ * {@link org.monarchinitiative.svart.vcf.VcfBreakendFormatter} when formatting unresolved breakends
+ * back to VCF representation (using {@code .} notation).
+ *
  * @author Jules Jacobsen <j.jacobsen@qmul.ac.uk>
  * @author Daniel Danis <daniel.danis@jax.org>
+ * @see GenomicBreakend
+ * @see BaseGenomicRegion
+ * @see org.monarchinitiative.svart.variant.DefaultGenomicBreakend
+ * @see org.monarchinitiative.svart.vcf.VcfBreakendResolver
+ * @see org.monarchinitiative.svart.vcf.VcfBreakendFormatter
  */
 final class UnresolvedGenomicBreakend extends BaseGenomicRegion<UnresolvedGenomicBreakend> implements GenomicBreakend {
 
-    private static final UnresolvedGenomicBreakend ONE_BASED_UNRESOLVED_BREAKEND = new UnresolvedGenomicBreakend(CoordinateSystem.ONE_BASED, 1);
-    private static final UnresolvedGenomicBreakend ZERO_BASED_UNRESOLVED_BREAKEND = new UnresolvedGenomicBreakend(CoordinateSystem.ZERO_BASED, 0);
+    private final String id;
 
-    private static final String ID = "";
-
-    private UnresolvedGenomicBreakend(CoordinateSystem coordinateSystem, int start) {
+    private UnresolvedGenomicBreakend(CoordinateSystem coordinateSystem, int start, String id) {
         super(Contig.unknown(), Strand.POSITIVE, Coordinates.of(coordinateSystem, start, start + Coordinates.endDelta(coordinateSystem)));
+        this.id = Objects.requireNonNullElse(id, "");
     }
 
-    static UnresolvedGenomicBreakend instance(CoordinateSystem coordinateSystem) {
-        return switch (coordinateSystem) {
-            case ONE_BASED -> ONE_BASED_UNRESOLVED_BREAKEND;
-            case ZERO_BASED -> ZERO_BASED_UNRESOLVED_BREAKEND;
-        };
+    static UnresolvedGenomicBreakend of(CoordinateSystem coordinateSystem) {
+        return new UnresolvedGenomicBreakend(coordinateSystem, calculateStart(coordinateSystem), "");
+    }
+
+    static UnresolvedGenomicBreakend of(CoordinateSystem coordinateSystem, String id) {
+        return new UnresolvedGenomicBreakend(coordinateSystem, calculateStart(coordinateSystem), id);
+    }
+
+    private static int calculateStart(CoordinateSystem coordinateSystem) {
+        return coordinateSystem == CoordinateSystem.ZERO_BASED ? 0 : 1;
     }
 
     @Override
     public String id() {
-        return ID;
+        return id;
     }
 
     @Override
     protected UnresolvedGenomicBreakend newRegionInstance(Contig contig, Strand strand, Coordinates coordinates) {
-        return instance(coordinates.coordinateSystem());
+        return of(coordinates.coordinateSystem(), id);
+    }
+
+    @Override
+    public boolean isUnresolved() {
+        return true;
     }
 
     @Override
     public boolean equals(Object o) {
-        return this == o;
+        if (!(o instanceof UnresolvedGenomicBreakend that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return Objects.hash(super.hashCode(), id);
     }
 
     @Override
     public String toString() {
         return "UnresolvedBreakend{" +
-                "contig=" + Contig.unknown().id() +
-                ", id='" + ID + '\'' +
-                ", strand=" + Strand.POSITIVE +
-                ", coordinateSystem=" + coordinateSystem() +
-                ", start=" + start() +
-                ", end=" + end() +
-                '}';
+               "contig=" + Contig.unknown().id() +
+               ", id='" + id + '\'' +
+               ", strand=" + Strand.POSITIVE +
+               ", coordinateSystem=" + coordinateSystem() +
+               ", start=" + start() +
+               ", end=" + end() +
+               '}';
     }
 }

--- a/src/test/java/org/monarchinitiative/svart/UnresolvedGenomicBreakendTest.java
+++ b/src/test/java/org/monarchinitiative/svart/UnresolvedGenomicBreakendTest.java
@@ -10,10 +10,27 @@ class UnresolvedGenomicBreakendTest {
 
     @ParameterizedTest
     @CsvSource({
-            "ONE_BASED",
-            "ZERO_BASED",
+            "ONE_BASED, 1",
+            "ZERO_BASED, 0",
     })
-    void instance(CoordinateSystem coordinateSystem) {
-        assertThat(UnresolvedGenomicBreakend.instance(coordinateSystem).coordinateSystem(), equalTo(coordinateSystem));
+    void constructorNoIdentifier(CoordinateSystem coordinateSystem, int start) {
+        UnresolvedGenomicBreakend instance = UnresolvedGenomicBreakend.of(coordinateSystem);
+        assertThat(instance.coordinateSystem(), equalTo(coordinateSystem));
+        assertThat(instance.start(), equalTo(start));
+        assertThat(instance.id(), equalTo(""));
+        assertThat(instance.mateId(), equalTo(""));
+        assertThat(instance.isUnresolved(), equalTo(true));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "ONE_BASED, bnd1",
+            "ZERO_BASED, bnd0",
+    })
+    void constructorWithIdentifier(CoordinateSystem coordinateSystem, String id) {
+        UnresolvedGenomicBreakend instance = UnresolvedGenomicBreakend.of(coordinateSystem, id);
+        assertThat(instance.coordinateSystem(), equalTo(coordinateSystem));
+        assertThat(instance.id(), equalTo(id));
+        assertThat(instance.isUnresolved(), equalTo(true));
     }
 }

--- a/src/test/java/org/monarchinitiative/svart/region/DefaultGenomicRegionTest.java
+++ b/src/test/java/org/monarchinitiative/svart/region/DefaultGenomicRegionTest.java
@@ -85,11 +85,11 @@ class DefaultGenomicRegionTest {
     @ParameterizedTest
     @CsvSource({
             "POSITIVE, ONE_BASED,  10,  1",
-            "POSITIVE, ONE_BASED,   0, 10",
-            "POSITIVE, ONE_BASED,   0, -1",
+            "POSITIVE, ONE_BASED,   -1, 10",
+            "POSITIVE, ONE_BASED,   -1, -1",
             "POSITIVE, ZERO_BASED, 10,  0",
             "POSITIVE, ZERO_BASED,  0, -1",
-            "POSITIVE, ZERO_BASED, -1, 10",
+            "POSITIVE, ZERO_BASED, -2, 10",
     })
     void testThrowsExceptionWithInvalidCoordinates(Strand inputStrand, CoordinateSystem inputCoords, int inputStart, int inputEnd) {
         assertThrows(InvalidCoordinatesException.class, () -> GenomicRegion.of(chr1, inputStrand, inputCoords, inputStart, inputEnd));
@@ -97,8 +97,8 @@ class DefaultGenomicRegionTest {
 
     @ParameterizedTest
     @CsvSource({
-            "POSITIVE, ONE_BASED,  1, 11",
-            "POSITIVE, ZERO_BASED, 0, 11",
+            "POSITIVE, ONE_BASED,  0, 12",
+            "POSITIVE, ZERO_BASED, 0, 12",
     })
     void testThrowsExceptionWithCoordinatesOutOfBounds(Strand inputStrand, CoordinateSystem inputCoords, int inputStart, int inputEnd) {
         assertThrows(CoordinatesOutOfBoundsException.class, () -> GenomicRegion.of(chr1, inputStrand, inputCoords, inputStart, inputEnd));

--- a/src/test/java/org/monarchinitiative/svart/region/GenomicRegionTest.java
+++ b/src/test/java/org/monarchinitiative/svart/region/GenomicRegionTest.java
@@ -23,11 +23,11 @@ class GenomicRegionTest {
     @ParameterizedTest
     @CsvSource({
             // given a coordinate on a contig of length 5
-            "ONE_BASED,   5,  6",
-            "ONE_BASED,   6,  6",
+            "ONE_BASED,   6,  7",
+            "ONE_BASED,   7,  7",
 
-            "ZERO_BASED,  5,  6",
-            "ZERO_BASED,  6,  6",
+            "ZERO_BASED,  6,  7",
+            "ZERO_BASED,  7,  7",
     })
     void coordinatesOutOfBounds(CoordinateSystem coordinateSystem, int start, int end) {
         Contig contig = TestContig.of(1, 5);

--- a/src/test/java/org/monarchinitiative/svart/variant/DefaultSequenceVariantTest.java
+++ b/src/test/java/org/monarchinitiative/svart/variant/DefaultSequenceVariantTest.java
@@ -1,7 +1,6 @@
 package org.monarchinitiative.svart.variant;
 
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.monarchinitiative.svart.*;
 import org.monarchinitiative.svart.Contig;
@@ -18,12 +17,8 @@ class DefaultSequenceVariantTest {
 
     private final Contig chr1 = TestContig.of(1, 1000);
 
-    /**
-     * Issue #
-     */
-    @Disabled("telomeric")
     @Test
-    void allowsTelomericVariants() {
+    void telomericSequenceVariant() {
         Coordinates coordinates = Coordinates.of(CoordinateSystem.ONE_BASED, 1001, 1002);
         GenomicVariant telomericVariant = GenomicVariant.of(chr1, "", Strand.POSITIVE, coordinates, "AT", "A");
         GenomicVariant oppositeStrand = telomericVariant.toOppositeStrand();

--- a/src/test/java/org/monarchinitiative/svart/variant/DefaultSymbolicVariantTest.java
+++ b/src/test/java/org/monarchinitiative/svart/variant/DefaultSymbolicVariantTest.java
@@ -29,15 +29,6 @@ class DefaultSymbolicVariantTest {
         assertThat(exception.getMessage(), containsString("Illegal non-symbolic alt allele 'TAA'"));
     }
 
-    @Disabled("telomeric")
-    @Test
-    void telomericBreakend() {
-        // chrUn_KI270435v1 92984 SV_318_2 N N[chr15:17081574[ 80
-        DefaultSymbolicVariant variant = DefaultSymbolicVariant.of(GenomicAssemblies.GRCh38p13().contigByName("chrUn_KI270435v1"), Strand.POSITIVE, CoordinateSystem.ONE_BASED, 92984, 92984, "N", "N[chr15:17081574[", 0);
-        System.out.println(variant.contig());
-        System.out.println(variant);
-    }
-
     @Test
     void shouldBeSymbolic() {
         GenomicVariant instance = GenomicVariant.of(chr1, "", Strand.POSITIVE, CoordinateSystem.ONE_BASED, 1, 1, "A", "<INS>", 100);
@@ -223,6 +214,18 @@ class DefaultSymbolicVariantTest {
         assertThat(instance.changeLength(), equalTo(0));
         assertThat(instance.mateId(), equalTo("bnd_v"));
         assertThat(instance.eventId(), equalTo("event_1"));
+    }
+
+    @Test
+    void symbolicTelomericBreakend() {
+        // chrUn_KI270435v1 92984 SV_318_2 N N[chr15:17081574[ 80
+        DefaultSymbolicVariant variant = DefaultSymbolicVariant.of(GenomicAssemblies.GRCh38p13().contigByName("chrUn_KI270435v1"), "SV_318_2", Strand.POSITIVE, CoordinateSystem.ONE_BASED, 92984, 92984, "N", "N[chr15:17081574[", 0);
+        assertThat(variant.contigName(), equalTo("HSCHRUN_RANDOM_128"));
+        assertThat(variant.coordinates(), equalTo(Coordinates.of(CoordinateSystem.ONE_BASED, 92984, 92984)));
+        assertThat(variant.id(), equalTo("SV_318_2"));
+        assertThat(variant.ref(), equalTo("N"));
+        assertThat(variant.alt(), equalTo("N[chr15:17081574["));
+        assertThat(variant.isBreakend(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
Relaxed Coordinates.validateCoordinates and Coordinates.validateCoordinatesOnContig to allow a one-base overflow at either end. 
Alter UnresolvedGenomicBreakend to allow for the addition of an id field